### PR TITLE
DANG-167: Add radio button component to Storybook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "dependencies": {
         "core-js": "^3.6.5",
         "vue": "^2.6.11"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "main": "./dist/ui-components.umd.min.js",
   "repository": {
     "type": "git",

--- a/src/components/Card/Card.mdx
+++ b/src/components/Card/Card.mdx
@@ -9,9 +9,6 @@ Cards are a flexible component used to display content in a variety of contexts.
   <Story id="components-card--primary" />
 </Preview>
 
-<br />
-<br />
-
 ## How to Use
 
 Please note: though you can only insert text in the Storybook demo, the card component will accept any valid HTML or Vue component.

--- a/src/components/RadioButton/RadioButton.mdx
+++ b/src/components/RadioButton/RadioButton.mdx
@@ -1,0 +1,28 @@
+import { Preview, Story, ArgsTable, PRIMARY_STORY } from '@storybook/addon-docs/blocks';
+import RadioButton from './RadioButton.vue';
+
+# Radio Button
+
+A radio button typically represents a single option in a group of related choices. Only one can be selected at a time.
+
+<Preview>
+  <Story id="components-radio-button--primary" />
+</Preview>
+
+## How to Use
+
+Most of the time, radio buttons should be grouped together using a `radio-group` component. The `name` prop should be the same across the group so that (1) HTML can use it to figure out which group a radio button is in, and ensure that only one button in the group is selected and (2) screen readers can accurately group options together.
+
+You can pass in the `v-model` prop to bind radio buttons to the parent component's data model.
+
+```html
+<radio-button
+  name="postcard-size"
+  value="4x6"
+  label="4x6"
+/>
+```
+
+## Props
+
+<ArgsTable story={PRIMARY_STORY} />

--- a/src/components/RadioButton/RadioButton.stories.js
+++ b/src/components/RadioButton/RadioButton.stories.js
@@ -1,0 +1,32 @@
+import RadioButton from './RadioButton.vue';
+import mdx from './RadioButton.mdx';
+
+export default {
+  title: 'Components/Radio Button',
+  component: RadioButton,
+  parameters: {
+    docs: {
+      page: mdx
+    }
+  },
+  argTypes: {
+    'v-model': {
+      control: {
+        type: null
+      }
+    }
+  }
+};
+
+const Template = (args, {argTypes}) => ({
+  props: Object.keys(argTypes),
+  components: { RadioButton },
+  template: '<radio-button v-bind="$props" />',
+});
+
+export const Primary = Template.bind({});
+Primary.args = {
+  name: 'postcard-size',
+  label: '4x6',
+  value: '4x6',
+}

--- a/src/components/RadioButton/RadioButton.vue
+++ b/src/components/RadioButton/RadioButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="['radio', {'radio--next-line': nextLine}, {'radio--disabled': disabled}]">
+  <div :class="['radio', {'radio--separate-lines': this.$parent.separateLines}, {'radio--disabled': disabled}]">
     <input
       type="radio"
       :class="['radio__input', {'radio__input--error': error}]"
@@ -19,9 +19,8 @@ export default {
   name: 'RadioButton',
   props: {
     modelValue: {
-      default: ''
+      default: null
     },
-    nextLine: Boolean,
     error: Boolean,
     name: String,
     value: String,
@@ -57,7 +56,7 @@ export default {
     margin-right: 15px;
   }
 
-  .radio--next-line {
+  .radio--separate-lines {
     display: block;
     margin-bottom: 5px;
   }
@@ -133,7 +132,10 @@ export default {
       + label::before {
         background: var(--color-white-mist);
         border-color: var(--color-gray-xl-dove);
-        box-sizing: border-box;
+      }
+
+      + label::after {
+        display: none;
       }
     }
   }

--- a/src/components/RadioGroup/RadioGroup.mdx
+++ b/src/components/RadioGroup/RadioGroup.mdx
@@ -1,0 +1,32 @@
+import { Preview, Story, ArgsTable, PRIMARY_STORY } from '@storybook/addon-docs/blocks';
+import RadioGroup from './RadioGroup.vue';
+
+# Radio Group
+
+A radio group represents a group of radio buttons.
+
+<Preview>
+  <Story id="components-radio-group--primary" />
+</Preview>
+
+## How to Use
+
+Wrap all radio buttons in a radio group with the title of the group passed in through the `legend` prop.
+
+Customizations exist for<br />
+(1) if radio buttons are on the same line or separate lines,<br />
+(2) if the legend is hidden, or<br />
+(3) if the input field is required.<br />
+If the legend is hidden, it will still be accessible to screen readers.
+
+```html
+<radio-group legend="Postcard Size">
+  <radio-button name="postcard-size" value="4x6" label="4x6" />
+  <radio-button name="postcard-size" value="5x7" label="5x7" />
+  <radio-button name="postcard-size" value="big" label="Really Big" />
+</radio-group>
+```
+
+## Props
+
+<ArgsTable story={PRIMARY_STORY} />

--- a/src/components/RadioGroup/RadioGroup.stories.js
+++ b/src/components/RadioGroup/RadioGroup.stories.js
@@ -1,0 +1,44 @@
+import RadioGroup from './RadioGroup.vue';
+import RadioButton from '../RadioButton/RadioButton.vue';
+import mdx from './RadioGroup.mdx';
+
+export default {
+  title: 'Components/Radio Group',
+  component: RadioGroup,
+  subcomponents: { RadioButton },
+  parameters: {
+    docs: {
+      page: mdx
+    }
+  },
+};
+
+const Template = (args, {argTypes}) => ({
+  props: Object.keys(argTypes),
+  components: { RadioGroup, RadioButton },
+  template: `
+    <radio-group v-bind="$props">
+      <radio-button
+        name="postcard-size"
+        label="4x6"
+        value="4x6"
+      />
+      <radio-button
+        name="postcard-size"
+        label="5x7"
+        value="5x7"
+      />
+      <radio-button
+        name="postcard-size"
+        label="Really Big"
+        value="big"
+      />
+    </radio-group>
+  `,
+});
+
+export const Primary = Template.bind({});
+Primary.args = {
+  legend: 'Postcard Size',
+  separateLines: false,
+}

--- a/src/components/RadioGroup/RadioGroup.vue
+++ b/src/components/RadioGroup/RadioGroup.vue
@@ -14,7 +14,8 @@ export default {
   props: {
     legend: String,
     srOnlyLegend: Boolean,
-    required: Boolean
+    separateLines: Boolean,
+    required: Boolean,
   }
 }
 </script>


### PR DESCRIPTION
## JIRA

* [https://lobsters.atlassian.net/browse/DANG-167](https://lobsters.atlassian.net/browse/DANG-167)

## Description

* Deleted extra line breaks from Card story documentation.
* Edited radio button/group components so that the `separate line` behavior (radio buttons stacked on top of one another instead of next to each other) is controlled via the radio group component, and not the individual buttons themselves.
* Added stories for radio button and radio group with documentation.

## Screenshots

Radio Button component page
![Screen Shot 2021-05-12 at 1 48 28 PM](https://user-images.githubusercontent.com/20443660/118035773-e9f2cf80-b328-11eb-9c56-c98c4b0d5e08.png)

Radio Button documentation page
![Screen Shot 2021-05-12 at 1 48 44 PM](https://user-images.githubusercontent.com/20443660/118035802-f24b0a80-b328-11eb-8545-16a7c0b83725.png)

Radio Group component page
![Screen Shot 2021-05-12 at 1 49 09 PM](https://user-images.githubusercontent.com/20443660/118035815-f70fbe80-b328-11eb-899d-5d8adb83889c.png)

Radio Group documentation page
![Screen Shot 2021-05-12 at 1 49 21 PM](https://user-images.githubusercontent.com/20443660/118035833-fd9e3600-b328-11eb-904a-9a49940e32fc.png)

Video I made because STORYBOOK IS SO COOL
https://user-images.githubusercontent.com/20443660/118036090-5d94dc80-b329-11eb-818d-c0570948e5ba.mov

## Reviewer Checklist

### Testing

How to test:
* Pull down branch, `npm install` (if you haven't already), `npm run storybook`
* Click into `Components/Radio Button` and `Components/Radio Group`, fiddle with the switches, marvel at it

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
