### PR TITLE
DANG-180, pt 2: Add FontAwesome token & change workflow name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,9 @@ jobs:
     steps:
       # Checkout the code as the first step.
       - checkout
+      - run:
+          name: Set FontAwesome token
+          command: npm config set //npm.fontawesome.com/:_authToken $FONTAWESOME_NPM_AUTH_TOKEN
       # Next, the node orb's install-packages step will install the dependencies from a package.json.
       # The orb install-packages step will also automatically cache them for faster future runs.
       - node/install-packages
@@ -33,6 +36,6 @@ jobs:
 workflows:
   # CircleCI will run this workflow on every commit.
   # For more details on extending your workflow, see the configuration docs: https://circleci.com/docs/2.0/configuration-reference/#workflows
-  sample: 
+  build-test-lint: 
     jobs:
       - build-test-lint


### PR DESCRIPTION
## JIRA

* [https://lobsters.atlassian.net/browse/DANG-180](https://lobsters.atlassian.net/browse/DANG-180)

## Description

* Merged [FontAwesome PR](https://github.com/lob/ui-components/pull/11) and then forgot that we need to give FA a token and merged [CircleCI config](https://github.com/lob/ui-components/pull/14) and the build failed. 😬 
* Also changed the name of the workflow to be more representative of what it actually does.

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

Run `circleci local execute --job build-test-lint -e FONTAWESOME_NPM_AUTH_TOKEN=${TOKEN}` ([can't connect to UI environment variables](https://circleci.com/docs/2.0/local-cli/#limitations-of-running-jobs-locally))

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
