### PR TITLE
Update main nav contrast, format switch group name

### DIFF
--- a/src/components/MainNavigation/MainNavigationChildItem.vue
+++ b/src/components/MainNavigation/MainNavigationChildItem.vue
@@ -1,7 +1,7 @@
 <template>
   <li
     :class="[
-      'no-underline py-1 max-h-12 my-px flex items-center font-light text-sm text-left text-gray-300 hover:text-primary-300',
+      'no-underline py-1 max-h-12 my-px flex items-center font-light text-sm text-left text-gray-500 hover:text-primary-700',
       { 'font-medium bg-white-300 rounded-l-full': active}
     ]"
     data-testid="nav-child-item"

--- a/src/components/MainNavigation/MainNavigationItem.vue
+++ b/src/components/MainNavigation/MainNavigationItem.vue
@@ -3,10 +3,10 @@
     <component
       :is="tag"
       :class="[
-        'no-underline py-4 px-6 max-h-12 flex items-center w-full font-light text-sm text-left text-gray-300 relative overflow-hidden hover:text-primary-300 focus:outline-none focus:ring-2 focus:ring-primary-100 focus:border-transparent'
+        'no-underline py-4 px-6 max-h-12 flex items-center w-full font-light text-sm text-left text-gray-500 relative overflow-hidden hover:text-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-100 focus:border-transparent'
       ]"
       :to="to"
-      active-class="text-normal bg-white-300"
+      active-class="text-normal bg-white-300 font-medium"
       @click.native.stop
       @[clickEvent].stop="toggleSubNav"
     >

--- a/src/components/Switch/SwitchGroup.stories.js
+++ b/src/components/Switch/SwitchGroup.stories.js
@@ -3,7 +3,7 @@ import SwitchItem from './SwitchItem.vue';
 import mdx from './SwitchGroup.mdx';
 
 export default {
-  title: 'Components/SwitchGroup',
+  title: 'Components/Switch Group',
   component: SwitchGroup,
   subcomponents: { SwitchItem },
   parameters: {


### PR DESCRIPTION
## Description

* Main nav was updated for color contrast ratios. Also, we had a heavier font weight on `MainNavChildItem` but not on `MainNavItem`, so added that class to the latter too.
* Really small thing: it was bothering me that `SwitchGroup` was the only component in Storybook without a space between. 😬 

## Screenshots
Before, unhovered state
![Screen Shot 2021-06-03 at 10 09 13 AM](https://user-images.githubusercontent.com/20443660/120676953-cf0d0a00-c453-11eb-9306-9d59f00d78b2.png)

After, unhovered state
![Screen Shot 2021-06-03 at 10 06 56 AM](https://user-images.githubusercontent.com/20443660/120676867-b43a9580-c453-11eb-8468-4170642cc5c8.png)

Before, hovered state
![Screen Shot 2021-06-03 at 10 09 18 AM](https://user-images.githubusercontent.com/20443660/120676943-cc121980-c453-11eb-8765-46f735bed029.png)

After, hovered state
![Screen Shot 2021-06-03 at 10 07 10 AM](https://user-images.githubusercontent.com/20443660/120676818-a8e76a00-c453-11eb-9ef9-a44708ce932b.png)
