### PR TITLE
DANG-192/reusable-shadows

### DIFF
--- a/src/components/Card/Card.vue
+++ b/src/components/Card/Card.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="card p-6">
+  <div class="shadow p-6">
     <slot name="content" />
   </div>
 </template>
@@ -9,9 +9,3 @@ export default {
   name: 'Card'
 };
 </script>
-
-<style scoped lang="scss">
-  .card {
-    box-shadow: 0 5px 14px rgba(44, 67, 81, 0.13), 0 0 4px rgba(44, 67, 81, 0.02);
-  }
-</style>

--- a/src/components/Checkbox/Checkbox.vue
+++ b/src/components/Checkbox/Checkbox.vue
@@ -105,7 +105,7 @@ export default {
 
 <style scoped lang="scss">
 .checkbox:hover input ~ .checkmark {
-  box-shadow: 0 0 4px var(--color-primary-rgb-l);
+  @apply shadow-input;
 }
 
 .checkbox input:focus ~ .checkmark {

--- a/src/components/RadioButton/RadioButton.vue
+++ b/src/components/RadioButton/RadioButton.vue
@@ -115,8 +115,7 @@ export default {
   }
 
   &:checked + label::after {
-    box-shadow: 0 0 4px var(--color-primary-rgb-xl);
-
+    @apply shadow-input-selected;
     @apply bg-primary-500;
     @apply border-l;
   }
@@ -126,7 +125,7 @@ export default {
   }
 
   &:hover + label::before {
-    box-shadow: 0 0 4px var(--color-primary-rgb-l);
+    @apply shadow-input;
   }
 
   &:focus + label::before {

--- a/src/components/Switch/SwitchGroup.vue
+++ b/src/components/Switch/SwitchGroup.vue
@@ -5,7 +5,7 @@
     <legend :class="['text-sm font-normal normal-case tracking-normal text-gray-500 mb-1 border-b-0', {'sr-only': srOnlyLegend}]">
       {{ legend }}
     </legend>
-    <div class="lob-switch-group flex p-1 bg-white rounded">
+    <div class="shadow flex p-1 bg-white rounded">
       <slot />
     </div>
   </fieldset>
@@ -26,10 +26,4 @@ export default {
   }
 };
 </script>
-
-<style scoped lang="scss">
-  .lob-switch-group {
-    box-shadow: 0 5px 14px rgba(44, 67, 81, 0.13), 0 0 4px rgba(44, 67, 81, 0.02);
-  }
-</style>
 

--- a/src/components/Textarea/Textarea.vue
+++ b/src/components/Textarea/Textarea.vue
@@ -64,7 +64,7 @@ textarea {
   min-height: 10rem;
 
   &:hover:not(:disabled) {
-    box-shadow: 0 5px 14px rgba(44, 67, 81, 0.13), 0 0 4px rgba(44, 67, 81, 0.02);
+    @apply shadow;
   }
 }
 </style>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -110,6 +110,11 @@ module.exports = {
     fill: (theme) => ({
       ...theme('colors')
     }),
+    boxShadow: {
+      DEFAULT: '0 5px 14px rgba(44, 67, 81, 0.13), 0 0 4px rgba(44, 67, 81, 0.02)',
+      input: '0px 0px 4px 2px rgba(24, 118, 219, 0.2)',
+      'input-selected': '0px 0px 4px 2px rgba(24, 118, 219, 0.4)'
+    },
     extend: {
       borderWidth: {
         3: '3px'


### PR DESCRIPTION
## JIRA

* A link to the JIRA ticket

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

Create reusable box-shadow config in tailwind.

Added `shadow` to use the default shadow that appears in most of the elements in Figma. And `shadow-input` and `shadow-input-selected` for radios and checkboxes.

There may still be some one-off shadows we need to define in scoped styles since they aren't used anywhere else in Figma (I'm looking at you buttons...)

<!--
## Screenshots
- before and after screenshots for features with visual changes
-->

<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
