### PR TITLE
Support additional text-like inputs

### DIFF
--- a/src/components/TextInput/TextInput.stories.js
+++ b/src/components/TextInput/TextInput.stories.js
@@ -22,6 +22,12 @@ export default {
       control: {
         type: 'select'
       }
+    },
+    type: {
+      options: ['date', 'email', 'number', 'tel', 'text', 'url'],
+      control: {
+        type: 'select'
+      }
     }
   }
 };

--- a/src/components/TextInput/TextInput.stories.js
+++ b/src/components/TextInput/TextInput.stories.js
@@ -24,7 +24,7 @@ export default {
       }
     },
     type: {
-      options: ['date', 'email', 'number', 'tel', 'text', 'url'],
+      options: ['date', 'email', 'number', 'password', 'tel', 'text', 'url'],
       control: {
         type: 'select'
       }

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -22,7 +22,7 @@
     <input
       :id="id"
       ref="input"
-      type="text"
+      :type="type"
       :value="modelValue"
       :class="[
         'rounded pl-2 pt-3 pb-4 leading-5 w-full text-gray-500 focus:outline-none focus:ring-2 focus:ring-primary-100 focus:border-transparent',
@@ -72,6 +72,28 @@ export default {
       type: String,
       default: '',
       required: true
+    },
+    type: {
+      type: String,
+      default: 'text',
+      validator: function (value) {
+        return ['date', 'email', 'number', 'tel', 'text', 'url'].includes(value);
+      }
+    },
+    // Used by number inputs.
+    min: {
+      type: String,
+      default: null
+    },
+    // Used by number inputs.
+    max: {
+      type: String,
+      default: null
+    },
+    // Used by tel inputs.
+    pattern: {
+      type: String,
+      default: null
     },
     label: {
       type: String,

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -77,7 +77,7 @@ export default {
       type: String,
       default: 'text',
       validator: function (value) {
-        return ['date', 'email', 'number', 'tel', 'text', 'url'].includes(value);
+        return ['date', 'email', 'number', 'password', 'tel', 'text', 'url'].includes(value);
       }
     },
     // Used by number inputs.

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -24,6 +24,9 @@
       ref="input"
       :type="type"
       :value="modelValue"
+      :min="min"
+      :max="max"
+      :pattern="pattern"
       :class="[
         'rounded pl-2 pt-3 pb-4 leading-5 w-full text-gray-500 focus:outline-none focus:ring-2 focus:ring-primary-100 focus:border-transparent',
         {'!pl-4': !iconLeft},


### PR DESCRIPTION
Adds a `type` property to `TextInput` to support things like `date`, `password`, `email`, etc. since they are all kinds of text values.