### PR TITLE
Header tweaks

### DIFF
--- a/src/components/MegaMenu/MegaMenu.mdx
+++ b/src/components/MegaMenu/MegaMenu.mdx
@@ -41,7 +41,7 @@ The mega menu item component is used for displaying a single item in the nested 
 
 The main navigation item component can render as a traditional link (hooked up to your app's routing) or as an anchor tag depending on if the link is internal to your app's routing or external.
 
-You must provide an image source and optionally a subtitle to display for the item.
+You can optionally provide an image source as well as a subtitle to display for the item.
 
 You can also choose to pass in the `small` prop in order to limit the amount of white space around the item.
 

--- a/src/components/MegaMenu/MegaMenuItem.vue
+++ b/src/components/MegaMenu/MegaMenuItem.vue
@@ -16,7 +16,9 @@
         :class="[
           'self-center transition-transform duration-200 ease-linear transform hover:scale-110',
           {'w-10 h-10': small},
-          {'w-12 h-12': !small}]"
+          {'w-12 h-12': !small},
+          // Preserves the spacing this element creates.
+          {'invisible': !imageSource}]"
       >
       <div class="pl-2 text-gray-900">
         <span
@@ -45,7 +47,8 @@ export default {
     },
     imageSource: {
       type: String,
-      required: true
+      required: false,
+      default: null
     },
     subtitle: {
       type: String,

--- a/src/components/TopNavbar/TopNavbar.stories.js
+++ b/src/components/TopNavbar/TopNavbar.stories.js
@@ -31,7 +31,7 @@ const Template = (args, { argTypes }) => ({
       >
       <div class="md:pl-6">
         <MegaMenu id="1" title="Some menu" navKey="" :mobileNavs="{}">
-          <MegaMenuItem to="/settings/main/account" :imageSource="$getConst('lobAssetsUrl') + '/dashboard/navbar/settings.svg'" small>
+          <MegaMenuItem to="/settings/main/account" small>
             Some menu item
           </MegaMenuItem>
           <MegaMenuItem to="/settings/main/account" :imageSource="$getConst('lobAssetsUrl') + '/dashboard/navbar/settings.svg'" small>

--- a/src/components/TopNavbar/TopNavbar.vue
+++ b/src/components/TopNavbar/TopNavbar.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="left-0 top-0 bg-white fixed w-full rounded">
     <nav
-      class="z-30 max-w-7xl w-full m-0 m-auto py-4 px-9 md:px-12 lg:px-6 md:flex mx-auto items-center bg-transparent w-auto max-w-none relative justify-between lg:justify-start"
+      class="z-30 w-full m-0 m-auto py-4 px-9 md:px-12 lg:px-6 md:flex mx-auto items-center bg-transparent w-auto max-w-none relative justify-between lg:justify-start"
     >
       <slot />
     </nav>


### PR DESCRIPTION
- Make navigation header full-width (it was a bit shy before)
- Make icon for `MegaMenuItem`s optional (without affecting their spacing)

![image](https://user-images.githubusercontent.com/60271685/122826031-89e03900-d297-11eb-9dc3-97dc4ed74662.png)
