### PR TITLE
Make Dropdown size consistent with TextInput

### DIFF
--- a/src/components/Dropdown/Dropdown.mdx
+++ b/src/components/Dropdown/Dropdown.mdx
@@ -19,7 +19,7 @@ You can optionally provide a `placeholder` which will display in the select when
 Like other input types, you can provide boolean props for `required`, `disabled`, and `error`.
 
 Customizations exist for<br />
-(1) the size of the dropdown with the `size` prop: "small" (default) or "large"<br />
+(1) the size of the dropdown with the `size` prop: "default" or "small"<br />
 
 Example of using this component in a template with simple string options
 ```js

--- a/src/components/Dropdown/Dropdown.stories.js
+++ b/src/components/Dropdown/Dropdown.stories.js
@@ -14,7 +14,7 @@ export default {
   },
   argTypes: {
     size: {
-      options: ['small', 'large'],
+      options: ['small', 'default'],
       control: {
         type: 'select'
       }

--- a/src/components/Dropdown/Dropdown.vue
+++ b/src/components/Dropdown/Dropdown.vue
@@ -6,7 +6,7 @@
       :id="id"
       :class="['pb-2 text-gray-500',
                {'text-xs': small},
-               {'text-sm': large}]"
+               {'text-sm': default_}]"
     >{{ label }}</label>
     <div class="relative">
       <div
@@ -23,8 +23,8 @@
         :aria-disabled="disabled"
         :class="[
           'cursor-default bg-white border rounded border-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-100 focus:border-transparent hover:shadow',
-          {'text-sm py-1.5 px-2.5': small},
-          {'py-3.5 px-4': large},
+          {'text-sm py-2 px-2.5': small},
+          {'py-3 px-4': default_},
           {'!bg-white-300 !border-white-200 pointer-events-none': disabled},
           {'border-error': error}
         ]"
@@ -45,7 +45,7 @@
           :class="[
             'w-4 h-4 absolute right-2',
             {'top-3': small},
-            {'top-5': large}
+            {'top-5': default_}
           ]"
         />
       </div>
@@ -173,9 +173,9 @@ export default {
     },
     size: {
       type: String,
-      default: 'small',
+      default: 'default',
       validator: function (value) {
-        return ['small', 'large'].includes(value);
+        return ['default', 'small'].includes(value);
       }
     },
     required: {
@@ -212,8 +212,8 @@ export default {
     small () {
       return this.size === 'small';
     },
-    large () {
-      return this.size === 'large';
+    default_ () {
+      return this.size === 'default';
     },
     optionItems () {
       return this.placeholder ? [{ label: this.placeholder, disabled: this.required }, ...this.options] : this.options;


### PR DESCRIPTION
- Rename "large" to "default" in Dropdown
- Make that the default