### PR TITLE
Main navigation tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/Button/Button.stories.js
+++ b/src/components/Button/Button.stories.js
@@ -2,7 +2,7 @@ import LobButton from './Button.vue';
 import mdx from './Button.mdx';
 
 export default {
-  title: 'Components/Button',
+  title: 'Components/LobButton',
   component: LobButton,
   parameters: {
     docs: {

--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -28,7 +28,7 @@
 
 <script>
 export default {
-  name: 'Button',
+  name: 'LobButton',
   props: {
     variant: {
       type: String,


### PR DESCRIPTION
- Using 'span' instead of 'button' fixes a problem where the custom 'button' component is used with its own appearance.
- Removes redundant focused outlines since there is already enough styling to know which option is selected.