### PR TITLE
find way to handle document click without ref to bound element, stopPropagation instead

### DIFF
--- a/src/components/Datepicker/Datepicker.mdx
+++ b/src/components/Datepicker/Datepicker.mdx
@@ -18,7 +18,7 @@ You can also provide an `isDateDisabled` prop which is function that takes a sin
 
 If you would prefer that the calendar start on Mondays instead of Sundays,  you can provide a `firstDayOfWeek` prop set to 1 (the index of Monday) or any other index you'd like. By default, calendar weeks start on Sunday.
 
-Finally, to hook up the functionality to close the calendar when clicking outside of the datepicker and its parent element, you can provide a `boundComponent` prop which is a ref to the element that the user can click in to hide/show the calendar (usually an input).
+Finally, to hook up the functionality to close the calendar when clicking outside of the datepicker and its parent element, make sure to include `.stop` on the click event bound to the element that the user can click in to hide/show the calendar (usually an input). For example `<input @click.stop="open = !open" />`
 
 This component will emit `input` and `update:modelValue` events with the selected date as a vanilla JS Date object. It is up to you to decide how you would like to format and display that value in any inputs or presentation components. ([dayjs](https://day.js.org/) is a great little library for easy parsing and formatting)
 
@@ -36,7 +36,7 @@ const isDateDisabled = (date) => {
 ```html
 <label>
   Enter a date
-  <input @click="open = !open" :value="dateModel" ref="input">
+  <input @click.stop="open = !open" :value="dateModel" ref="input">
 </label>
 <datepicker v-model="dateModel" v-model:open="show" :boundComponent="$refs.input"></datepicker>
 ```

--- a/src/components/Datepicker/Datepicker.stories.js
+++ b/src/components/Datepicker/Datepicker.stories.js
@@ -26,9 +26,9 @@ const Template = (args, { argTypes }) => ({
   <div class="relative">
     <label>
       Enter a date
-      <input @click="show = !show" :value="dateModel" class="border border-gray-300" ref="input">
+      <input @click.stop="show = !show" :value="dateModel" class="border border-gray-300">
     </label>
-    <datepicker v-bind="args" v-model="dateModel" v-model:open="show" :boundComponent="$refs.input"></datepicker>
+    <datepicker v-bind="args" v-model="dateModel" v-model:open="show"></datepicker>
   </div>
   `
 });

--- a/src/components/Datepicker/Datepicker.vue
+++ b/src/components/Datepicker/Datepicker.vue
@@ -115,10 +115,6 @@ export default {
     isDateDisabled: {
       type: Function,
       default: () => false
-    },
-    boundComponent: {
-      type: Object,
-      default: null
     }
   },
   emits: ['update:modelValue', 'update:open', 'input'],
@@ -300,14 +296,11 @@ export default {
       this.hide();
     },
     onClickOutside ($event) {
-      const hasBoundElement = Boolean(this.boundComponent);
-
-      if (hasBoundElement) {
+      if (typeof this.$refs.container !== 'undefined') {
         const clickOnTheDatepickerContainer = this.$refs.container === $event.target;
-        const clickOnDatepickerChild = this.$refs.container.contains($event.target);
-        const clickOnBoundElement = this.boundComponent === $event.target;
+        const clickOnDatepickerChild = this.$refs.container && this.$refs.container.contains($event.target);
 
-        if (!clickOnTheDatepickerContainer && !clickOnDatepickerChild && !clickOnBoundElement) {
+        if (!clickOnTheDatepickerContainer && !clickOnDatepickerChild) {
           this.hide();
         }
       }

--- a/src/components/Datepicker/__tests__/Datepicker.spec.js
+++ b/src/components/Datepicker/__tests__/Datepicker.spec.js
@@ -407,22 +407,16 @@ describe('Datepicker', () => {
 
     });
 
-    describe('when its parent has a bound element ref', () => {
+    it('closes the datepicker when clicking outside the component', async () => {
+      props = { ...initialProps, open: true };
 
-      it('closes the datepicker when clicking outside the component and bound elements', async () => {
-        const input = document.createElement('input');
-        document.body.appendChild(input);
-        props = { ...initialProps, open: true, boundComponent: input };
+      const { emitted } = renderComponent({ props });
+      await fireEvent.click(document);
 
-        const { emitted } = renderComponent({ props });
-        await fireEvent.click(document);
+      const emittedEvent = emitted();
+      expect(emittedEvent).toHaveProperty('update:open');
 
-        const emittedEvent = emitted();
-        expect(emittedEvent).toHaveProperty('update:open');
-
-        expect(emittedEvent['update:open'][0][0]).toEqual(false);
-      });
-
+      expect(emittedEvent['update:open'][0][0]).toEqual(false);
     });
 
   });


### PR DESCRIPTION
## JIRA

* N/A

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

While working on the filter content component, I figured out a way to handle the document clicking (to close the component when clicking anywhere else) without using a bound component. So I went ahead and implemented that in the Datepicker too for consistency.

<!--
## Screenshots
- before and after screenshots for features with visual changes
-->

<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
