### PR TITLE
Fixes focus on text inputs

### DIFF
--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -16,7 +16,7 @@
     v-bind="$attrs"
     data-testId="input-container"
     :class="[
-      'flex rounded border border-gray-100',
+      'flex rounded border border-gray-100 focus-within:outline-none focus-within:ring-2 focus-within:ring-primary-100 focus-within:border-transparent',
       {'!border-0': withCopyButton},
       {'hover:shadow': !disabled && !readonly},
       {'border-error': error}
@@ -37,7 +37,7 @@
       :max="max"
       :pattern="pattern"
       :class="[
-        'rounded pl-2 pt-3 pb-4 leading-5 w-full text-gray-500 focus:outline-none focus:ring-2 focus:ring-primary-100 focus:border-transparent',
+        'rounded pl-2 pt-3 pb-4 leading-5 w-full text-gray-500 outline-none',
         {'!pl-4': !iconLeft},
         {'!pl-3 !pr-3 !py-2': small},
         {'border border-r-0 border-gray-100 rounded-tr-none rounded-br-none': withCopyButton},


### PR DESCRIPTION
While using the text input for the search bar, I realized focus was odd:
![image](https://user-images.githubusercontent.com/83967528/123729776-e3360280-d86b-11eb-9fb6-547286acb73b.png)

Replaced it with focus around the whole input, as per [the figma designs](https://www.figma.com/file/PFyulPE8zYVuRxRAhnhd7T/LOB-Design-System-(Updated)?node-id=30%3A282):
![image](https://user-images.githubusercontent.com/83967528/123729814-f0eb8800-d86b-11eb-98ff-97df69f627ed.png)
