### PR TITLE
Adds right prop to megamenu, for megamenus placed far right in the top navbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/MegaMenu/MegaMenu.vue
+++ b/src/components/MegaMenu/MegaMenu.vue
@@ -25,7 +25,7 @@
     <nav
       :id="dropdownListId"
       :aria-labelledby="dropdownToggleId"
-      :class="['hidden height-0 min-w-full bg-white-200 md:bg-white md:absolute', {'!block md:hidden': showMobileNav}, {'md:top-9 md:!block': showNav}, {'md:!hidden': !showNav}]"
+      :class="['hidden height-0 min-w-full bg-white-200 md:bg-white md:absolute', {'!block md:hidden': showMobileNav}, {'md:top-9 md:!block': showNav}, {'md:!hidden': !showNav}, {'md:right-0': right}]"
     >
       <div
         :class="['height-0 pt-6 pb-4 px-4 h-auto w-full mt-1 border-gray-100 opacity-100',
@@ -51,6 +51,10 @@ export default {
       required: true
     },
     collapsed: {
+      type: Boolean,
+      default: false
+    },
+    right: {
       type: Boolean,
       default: false
     }


### PR DESCRIPTION
Some megamenus are placed in the top right corner of the screen. For those, I added the right prop so they are visible.

![image](https://user-images.githubusercontent.com/83967528/124333914-ef6fd780-db6b-11eb-827f-d62c27af7f52.png)
