### PR TITLE
DANG-224: fix breadcrumb showing duplicate item when nested route

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/Breadcrumb/Breadcrumb.stories.js
+++ b/src/components/Breadcrumb/Breadcrumb.stories.js
@@ -10,14 +10,27 @@ export default {
   decorators: [
     routeDecorator('/envelopes/create', [
       {
-        path: '/envelopes',
-        name: 'Envelopes',
+        path: '/',
         component: {
-          template: routeTemplate('envelopes')
+          template: routeTemplate('overview')
+        }
+      },
+      {
+        path: '/envelopes',
+        component: {
+          template: '<div><h1>Letters</h1><router-view /></div>'
         },
         children: [
           {
+            path: '',
+            name: 'Envelopes',
+            component: {
+              template: routeTemplate('envelopes')
+            }
+          },
+          {
             path: 'create',
+            name: 'Create Envelope',
             component: {
               template: routeTemplate('create')
             }

--- a/src/components/Breadcrumb/Breadcrumb.vue
+++ b/src/components/Breadcrumb/Breadcrumb.vue
@@ -43,10 +43,16 @@ export default {
   },
   computed: {
     crumbs () {
-      const routes = [
-        { name: this.startName, path: START_LOCATION.path },
-        ...this.$route.matched
+      let routes = [
+        { name: this.startName, path: START_LOCATION.path }
       ];
+
+      if (this.$route.path !== START_LOCATION.path) {
+        // unique matched route records by path, grabbing the last duplicated if more than one
+        const uniqueMatchedByPath = [...new Map(this.$route.matched.map((matched) => [matched.path, matched])).values()];
+        routes = [...routes, ...uniqueMatchedByPath];
+      }
+
       return routes.map((routeRecord) => {
         const pathSegments = routeRecord.path.split('/');
         const lastChildInPath = pathSegments[pathSegments.length - 1];


### PR DESCRIPTION
## JIRA

* https://lobsters.atlassian.net/browse/DANG-224

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

When there is a nested route where the parent renders a `<router-view />` we were getting 2 matched route records returned by `this.$route.matched` which led to duplicate breadcrumb items. Made an update to grab the unique matched route records based on their paths, selecting the last record if there is more than one present (the last one will be the actual component which we want).


## Screenshots
Before
![image](https://user-images.githubusercontent.com/9774690/124636043-b9717280-de4d-11eb-8082-4c83bc3e4ca7.png)

After
![image](https://user-images.githubusercontent.com/9774690/124635933-9cd53a80-de4d-11eb-9cfc-bd3d791b4423.png)


<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
