### PR TITLE
Dang 267/datepicker bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.30",
+  "version": "0.0.43",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "0.0.30",
+      "version": "0.0.43",
       "dependencies": {
         "core-js": "^3.6.5",
+        "mitt": "^3.0.0",
         "vue": "^3.0.0",
         "vue-router": "^4.0.8"
       },
@@ -23939,6 +23940,11 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
+      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
+    },
     "node_modules/mixin-deep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
@@ -40939,7 +40945,6 @@
       "integrity": "sha512-pM7CR3yXB6L8Gfn6EmX7FLNE3+V/15I3o33GkSNsWvgsMp6HVGXKkXgojrcfUUauyL1LZOdvTmu4enU2RePGHw==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.11.0",
         "@babel/helper-compilation-targets": "^7.9.6",
         "@babel/helper-module-imports": "^7.8.3",
         "@babel/plugin-proposal-class-properties": "^7.8.3",
@@ -40952,7 +40957,6 @@
         "@vue/babel-plugin-jsx": "^1.0.3",
         "@vue/babel-preset-jsx": "^1.2.4",
         "babel-plugin-dynamic-import-node": "^2.3.3",
-        "core-js": "^3.6.5",
         "core-js-compat": "^3.6.5",
         "semver": "^6.1.0"
       }
@@ -54317,6 +54321,11 @@
         "stream-each": "^1.1.0",
         "through2": "^2.0.0"
       }
+    },
+    "mitt": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
+      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
     },
     "mixin-deep": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "engines": {
     "node": "14.16.1"
   },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   ],
   "dependencies": {
     "core-js": "^3.6.5",
+    "mitt": "^3.0.0",
     "vue": "^3.0.0",
     "vue-router": "^4.0.8"
   },

--- a/src/components/Datepicker/Datepicker.stories.js
+++ b/src/components/Datepicker/Datepicker.stories.js
@@ -16,10 +16,45 @@ export default {
 };
 
 const dateModel = null;
-const dateModel2 = null;
 const show = false;
-const show2 = false;
 const Template = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: {  Datepicker },
+  data: () => ({ dateModel, show }),
+  setup: () => ({ args }),
+  template: `
+  <div class="relative">
+    <label>
+      Enter a date
+      <input @click.stop="show = !show" :value="dateModel" class="border border-gray-300">
+    </label>
+    <datepicker v-bind="args" v-model="dateModel" v-model:open="show"></datepicker>
+  </div>
+  `
+});
+
+const today = new Date();
+const oneYearAgo = new Date();
+const oneYearFromNow = new Date();
+oneYearAgo.setMonth(today.getMonth() - 12);
+oneYearFromNow.setMonth(today.getMonth() + 12);
+
+const isDateDisabled = (date) => {
+  const dayOfWeek = date.getDay();
+  return dayOfWeek === DaysOfWeek.Saturday || dayOfWeek === DaysOfWeek.Sunday;
+};
+
+export const Primary = Template.bind({});
+Primary.args = {
+  id: 'test',
+  isDateDisabled,
+  min: oneYearAgo,
+  max: oneYearFromNow
+};
+
+const dateModel2 = null;
+const show2 = false;
+const WithMultipleTemplate = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: {  Datepicker },
   data: () => ({ dateModel, show, dateModel2, show2 }),
@@ -44,19 +79,8 @@ const Template = (args, { argTypes }) => ({
   `
 });
 
-const today = new Date();
-const oneYearAgo = new Date();
-const oneYearFromNow = new Date();
-oneYearAgo.setMonth(today.getMonth() - 12);
-oneYearFromNow.setMonth(today.getMonth() + 12);
-
-const isDateDisabled = (date) => {
-  const dayOfWeek = date.getDay();
-  return dayOfWeek === DaysOfWeek.Saturday || dayOfWeek === DaysOfWeek.Sunday;
-};
-
-export const Primary = Template.bind({});
-Primary.args = {
+export const WithMultipleDatepickers = WithMultipleTemplate.bind({});
+WithMultipleDatepickers.args = {
   id: 'test',
   isDateDisabled,
   min: oneYearAgo,

--- a/src/components/Datepicker/Datepicker.stories.js
+++ b/src/components/Datepicker/Datepicker.stories.js
@@ -16,19 +16,30 @@ export default {
 };
 
 const dateModel = null;
+const dateModel2 = null;
 const show = false;
+const show2 = false;
 const Template = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: {  Datepicker },
-  data: () => ({ dateModel, show }),
+  data: () => ({ dateModel, show, dateModel2, show2 }),
   setup: () => ({ args }),
   template: `
+  <div class="flex">
   <div class="relative">
     <label>
       Enter a date
       <input @click.stop="show = !show" :value="dateModel" class="border border-gray-300">
     </label>
     <datepicker v-bind="args" v-model="dateModel" v-model:open="show"></datepicker>
+  </div>
+  <div class="relative">
+    <label>
+      Enter a date
+      <input @click.stop="show2 = !show2" :value="dateModel2" class="border border-gray-300">
+    </label>
+    <datepicker v-bind="args" v-model="dateModel2" v-model:open="show2"></datepicker>
+  </div>
   </div>
   `
 });

--- a/src/components/Datepicker/Datepicker.vue
+++ b/src/components/Datepicker/Datepicker.vue
@@ -4,7 +4,7 @@
   <div
     ref="container"
     :class="[
-      'bg-white hidden shadow px-6 py-4.5 absolute',
+      'z-30 bg-white hidden shadow px-6 py-4.5 absolute',
       { '!block': open }
     ]"
     role="dialog"
@@ -83,6 +83,11 @@
 import { ArrowLeft, ArrowRight, Close } from '@/components/Icons';
 import DatepickerMonth from './DatepickerMonth.vue';
 import { Keys, startOfWeek, endOfWeek, startOfMonth, endOfMonth, setMonth, setYear, addDays, clamp, inRange } from '@/utils';
+import mitt from 'mitt';
+
+const emitter = mitt();
+
+const DATEPICKER_OPEN_EVENT = 'datepicker-open';
 
 export default {
   name: 'Datepicker',
@@ -162,6 +167,9 @@ export default {
       ];
     }
   },
+  created () {
+    emitter.on(DATEPICKER_OPEN_EVENT, this.handleOtherDatepickerOpened);
+  },
   mounted () {
     if (this.open) {
       this.$refs.month.focusDate();
@@ -170,9 +178,11 @@ export default {
   },
   unmounted () {
     window.removeEventListener('click', this.onClickOutside);
+    emitter.off(DATEPICKER_OPEN_EVENT, this.handleOtherDatepickerOpened);
   },
   updated () {
     if (this.open) {
+      emitter.emit(DATEPICKER_OPEN_EVENT, this.$refs.container);
       this.$refs.month.focusDate();
     }
   },
@@ -319,6 +329,11 @@ export default {
         if (!clickOnTheDatepickerContainer && !clickOnDatepickerChild) {
           this.hide();
         }
+      }
+    },
+    handleOtherDatepickerOpened (datepickerEl) {
+      if (this.$refs.container !== datepickerEl) {
+        this.hide();
       }
     },
     hide () {


### PR DESCRIPTION
## JIRA

* https://lobsters.atlassian.net/browse/DANG-267

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

When more than 1 datepicker are present on the page, they all stayed open. We want only the most recently opened datepicker to be open.

We're using [mitt](https://github.com/developit/mitt), a tiny event bus package, to handle emitting global events. Mitt is the Vue 3 recommended library for event emitting since they removed the event emitter API from Vue 2.

Also added z-index since that was breaking for Marius on the Overview page.

<!--
## Screenshots
- before and after screenshots for features with visual changes
-->

<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
