### PR TITLE
useCapture on window click events to correctly dispatch events for nested components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/Datepicker/Datepicker.vue
+++ b/src/components/Datepicker/Datepicker.vue
@@ -21,6 +21,7 @@
       {{ t('datepicker.keyboardInstruction') }}
     </div>
     <button
+      v-if="hideable"
       ref="firstFocusableElement"
       class="text-gray-700 opacity-0 focus:opacity-100 absolute right-2 top-2 focus:outline-none focus:ring-2 focus:ring-primary-100 focus:border-transparent"
       @keydown="handleFirstFocusableKeydown"
@@ -183,7 +184,7 @@ export default {
     if (this.open) {
       this.$refs.month.focusDate();
     }
-    window.addEventListener('click', this.onClickOutside);
+    window.addEventListener('click', this.onClickOutside, true);
   },
   unmounted () {
     window.removeEventListener('click', this.onClickOutside);

--- a/src/components/FilterContent/FilterContent.vue
+++ b/src/components/FilterContent/FilterContent.vue
@@ -53,7 +53,7 @@ export default {
     emitter.on(FILTER_OPEN_EVENT, this.handleOtherFilterOpened);
   },
   mounted () {
-    window.addEventListener('click', this.onClickOutside);
+    window.addEventListener('click', this.onClickOutside, true);
   },
   unmounted () {
     window.removeEventListener('click', this.onClickOutside);


### PR DESCRIPTION
## JIRA

* N/A

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

When datepickers are nested in filters, the click events on the window were firing in the wrong order. This caused the filters to be hidden if you clicked anywhere in the datepicker. We're now using `useCapture` to capture the events and dispatch them in the right order.

<!--
## Screenshots
- before and after screenshots for features with visual changes
-->

<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
