### PR TITLE
Shallow equality check when opts are objs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/Dropdown/Dropdown.vue
+++ b/src/components/Dropdown/Dropdown.vue
@@ -106,7 +106,7 @@
 import { ChevronDown } from '@/components/Icons';
 import DropdownItemGroup from './DropdownItemGroup';
 import DropdownItem from './DropdownItem';
-import { findLastIndex } from '@/utils';
+import { findLastIndex, shallowEquals } from '@/utils';
 
 if (!Array.prototype.findLastIndex) {
   Array.prototype.findLastIndex = findLastIndex; //eslint-disable-line 
@@ -201,9 +201,9 @@ export default {
   data () {
     return {
       // active option index
-      activeIndex: (this.options && this.options.findIndex((o) => o.label === this.modelValue || o === this.modelValue)) || -1,
+      activeIndex: -1,
       // selected option index
-      selectedIndex: (this.options && this.options.findIndex((o) => o.label === this.modelValue || o === this.modelValue)) || -1,
+      selectedIndex: -1,
       // menu state
       open: false,
       // prevent menu closing before click completed
@@ -248,6 +248,11 @@ export default {
     activeId () {
       return this.open ? `${this.id}-${this.activeIndex}` : '';
     }
+  },
+  created () {
+    const index = (this.flattenedOptions && this.flattenedOptions.findIndex((o) => o.label === this.modelValue || shallowEquals(o, this.modelValue))) || -1;
+    this.activeIndex = index;
+    this.selectedIndex = index;
   },
   updated () {
     if (this.open && this.isScrollable(this.$refs.listbox) && this.$refs.activeOption) {

--- a/src/utils/__tests__/object.test.js
+++ b/src/utils/__tests__/object.test.js
@@ -1,0 +1,44 @@
+import { shallowEquals } from '../object';
+
+describe('object utils', () => {
+
+  describe('shallowEquals', () => {
+
+    let obj1;
+    let obj2;
+
+    it('throws an error when either obj is null or undefined', () => {
+      obj1 = { a: 1, b: 2 };
+      obj2 = null;
+      expect(() => {
+        shallowEquals(obj1, obj2);
+      }).toThrow('Cannot convert undefined or null to object');
+    });
+
+    it('returns false when objects have different number of keys', () => {
+      obj1 = { a: 1, b: 2 };
+      obj2 = { a: 1, b: 2, c: 3 };
+      expect(shallowEquals(obj1, obj2)).toEqual(false);
+    });
+
+    it('returns false when objects have different keys', () => {
+      obj1 = { a: 1, b: 2 };
+      obj2 = { a: 1, c: 2 };
+      expect(shallowEquals(obj1, obj2)).toEqual(false);
+    });
+
+    it('returns false when objects have different values for same keys', () => {
+      obj1 = { a: 1, b: 2 };
+      obj2 = { a: 1, b: 3 };
+      expect(shallowEquals(obj1, obj2)).toEqual(false);
+    });
+
+    it('returns true when objects have the same number of keys and same values for same keys', () => {
+      obj1 = { a: 1, b: 2, c: 3 };
+      obj2 = { a: 1, b: 2, c: 3 };
+      expect(shallowEquals(obj1, obj2)).toEqual(true);
+    });
+
+  });
+
+});

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,3 +1,4 @@
 export * from './array';
 export * from './date';
 export * from './keyboard';
+export * from './object';

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -1,0 +1,6 @@
+export const shallowEquals = (obj1, obj2) => {
+  return Object.keys(obj1).length === Object.keys(obj2).length &&
+  Object.keys(obj1).every((key) =>
+    obj2.hasOwnProperty(key) && obj1[key] === obj2[key]
+  );
+};


### PR DESCRIPTION
## JIRA

* N/A

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

Javascript objects are passed by reference, duh. Need to check shallow equality rather than deep equality when checking for which obj the model value matches.

<!--
## Screenshots
- before and after screenshots for features with visual changes
-->

<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
