### PR TITLE
Small radio adjustments: Change label to flex, make inner circle smaller

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.64",
+  "version": "0.0.65",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.64",
+  "version": "0.0.65",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/RadioButton/RadioButton.vue
+++ b/src/components/RadioButton/RadioButton.vue
@@ -26,7 +26,7 @@
     <label
       :for="value"
       :class="[
-        'text-sm font-light relative inline-block ml-6',
+        'text-sm font-light relative flex ml-6',
         { 'cursor-not-allowed': disabled || readonly }
       ]"
     >
@@ -121,14 +121,14 @@ input {
 
   + label::after {
     content: "";
-    left: -18px;
+    left: -17px;
+    top: 7px;
 
     @apply absolute;
-    @apply h-2.5;
+    @apply h-2;
     @apply inline-block;
     @apply rounded-full;
-    @apply top-1.5;
-    @apply w-2.5;
+    @apply w-2;
   }
 
   &:checked + label::after {


### PR DESCRIPTION
## JIRA

* N/A

## Description

* A few more radio button adjustments. Label needs to be `flex` so that it and the tooltip can go on the same line and aligned vertically without messing up other stuff. I thought the inner circle of the radio button was too large before and looked a bit wonky, so make it slightly smaller.