### PR TITLE
Adds border to all buttons for consistent heights

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.65",
+  "version": "0.0.66",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "0.0.56",
+      "version": "0.0.66",
       "dependencies": {
         "core-js": "^3.6.5",
         "mitt": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.66",
+  "version": "0.0.67",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -4,7 +4,7 @@
       'flex justify-center items-center disabled:text-gray-500 focus:outline-none focus:ring-2 focus:ring-primary-100 focus:border-transparent',
       { 'rounded': !link || !none },
       {
-        'primary bg-primary-500 text-white active:bg-primary-700 disabled:bg-white-300': primary
+        'primary bg-primary-500 border border-primary-500 text-white active:bg-primary-700 disabled:bg-white-300': primary
       },
       {
         'secondary bg-white-200 border border-primary-500 text-primary-500 active:text-primary-700 active:border-primary-700 disabled:border-gray-100':
@@ -15,10 +15,10 @@
           tertiary
       },
       {
-        'success bg-success !text-white active:bg-success-700': success
+        'success bg-success border border-success-500 !text-white active:bg-success-700': success
       },
       {
-        'error bg-error !text-white active:bg-error-700': error
+        'error bg-error border border-error-500 !text-white active:bg-error-700': error
       },
       { 'underline text-primary-300 hover:text-primary-500': link },
       { 'block': none },


### PR DESCRIPTION
## Description

The `primary`, `success`, and `error` variants were 2 pixels shorter than the `tertiary` and `secondary` variants, because they lacked borders. This PR fixes that.
![image](https://user-images.githubusercontent.com/83967528/126845307-cf29c369-7dd7-45be-af92-79d6d854f786.png)
![image](https://user-images.githubusercontent.com/83967528/126845317-79e28677-7120-4c45-95f8-daaa3190f01c.png)


## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
