### PR TITLE
DANG 308: remove extra shadow from MegaMenu dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.77",
+  "version": "0.0.78",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/MegaMenu/MegaMenu.vue
+++ b/src/components/MegaMenu/MegaMenu.vue
@@ -25,7 +25,7 @@
     <nav
       :id="dropdownListId"
       :aria-labelledby="dropdownToggleId"
-      :class="['hidden height-0 min-w-full bg-white-200 xl:bg-white xl:absolute', {'!block xl:hidden': showMobileNav}, {'xl:top-9 xl:!block': showNav}, {'xl:!hidden': !showNav}, {'xl:right-0': right}]"
+      :class="['hidden height-0 min-w-full xl:rounded-lg xl:bg-white xl:absolute', {'!block xl:hidden': showMobileNav}, {'xl:top-9 xl:!block': showNav}, {'xl:!hidden': !showNav}, {'xl:right-0': right}]"
     >
       <div
         :class="['height-0 pt-6 pb-4 px-4 h-auto w-full mt-1 border-gray-100 opacity-100',


### PR DESCRIPTION
## JIRA

* [A link to the JIRA ticket](https://lobsters.atlassian.net/secure/RapidBoard.jspa?rapidView=106&projectKey=DANG&modal=detail&selectedIssue=DANG-308)

## Description

* Removes the extra bg from the outer div that showed as an extra non-rounded shadow behind the top-nav's (megamenu) dropdown.

## Reviewer Checklist

This is really hard to see on StoryBook but visible on the dashboard. You could see the little pointy corners (not rounded) by changing storybook to darkmode - but the top shadow is hard to catch.
