### PR TITLE
fix copy button size in TextInput

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.79",
+  "version": "0.0.80",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -49,25 +49,25 @@
       >
         <slot name="iconRight" />
       </div>
-      <lob-button
+      <button
         v-if="withCopyButton"
-        :small="small"
-        class="rounded-tl-none rounded-bl-none pl-3 pr-3"
+        :class="['rounded-tr-md rounded-br-md text-white bg-primary-500 border px-3',
+                 { 'h-12': !small },
+                 { 'h-10': small }
+        ]"
         @click="copyToClipboard"
       >
         Copy
-      </lob-button>
+      </button>
     </div>
   </div>
 </template>
 
 <script>
 import LobLabel from '../LobLabel/LobLabel.vue';
-import LobButton from './../Button/Button.vue';
 export default {
   name: 'TextInput',
   components: {
-    LobButton,
     LobLabel
   },
   props: {


### PR DESCRIPTION
## Description

* Fixes the misbehaving copy-button.

**before:**
<img width="372" alt="Screen Shot 2021-08-03 at 8 41 00 AM" src="https://user-images.githubusercontent.com/50080618/128045460-ee524d39-6842-4fa1-bc7d-e0b12df823bf.png">

**after:**
<img width="372" alt="Screen Shot 2021-08-03 at 8 41 07 AM" src="https://user-images.githubusercontent.com/50080618/128045482-c1823d42-cf9a-43a6-b7f6-0da16a630770.png">

