### PR TITLE
allow FilterContent to bubble event based on bound element

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.81",
+  "version": "0.0.82",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/FilterContent/FilterContent.mdx
+++ b/src/components/FilterContent/FilterContent.mdx
@@ -3,7 +3,7 @@ import FilterContent from './FilterContent.vue';
 
 # FilterContent
 
-FilterContent is a stylized, accessible component for seeing a calendar and choosing a date.
+FilterContent is a stylized component for displaying some content (usually filters and form fields) in a popover element when the user interacts with an element in some way (usually a button click).
 
 <Preview>
   <Story id="components-filtercontent--primary" />
@@ -11,6 +11,8 @@ FilterContent is a stylized, accessible component for seeing a calendar and choo
 
 ## How to Use
 To use the filter content component, you must provide a `v-model:open` of type Boolean (controls whether the filter content is visible).
+
+If you want to make it so that clicking the button (or whatever element changes the `v-model:open` value) toggles the filter content (rather than just opening), be sure to add a ref to the element and then pass that ref to FilterContent using the `bound-element` prop.
 
 The filter content is positioned absolutely so you'll want to be sure to position its parent `relative` in order to have it show up in the proper position (it will always be positioned absolutely to its nearest ancestor that is positioned relative).
 
@@ -23,8 +25,8 @@ This component will emit `update:open` events with a boolean for whether the fil
 Example of using this component in a template without a header
 ```html
 <div class="relative">
-  <Button @click.stop="open = !open" size="small">Filter by</Button>
-  <filter-content v-model:open="open">
+  <Button ref="filterContentCtrl" @click.stop="open = !open" size="small">Filter by</Button>
+  <filter-content v-model:open="open" :bound-element="$refs.filterContentCtrl">
     <checkbox
       label="Postcards"
       v-model="selectedFilters"

--- a/src/components/FilterContent/FilterContent.stories.js
+++ b/src/components/FilterContent/FilterContent.stories.js
@@ -22,8 +22,8 @@ const Template = (args, { argTypes }) => ({
   setup: () => ({ args }),
   template: `
     <div class="relative">
-      <LobButton @click.stop="open = !open" size="small">Filter by</LobButton>
-      <filter-content v-model:open="open">
+      <LobButton ref="filterContentCtrl" @click.stop="open = !open" size="small">Filter by</LobButton>
+      <filter-content v-model:open="open" :bound-element="$refs.filterContentCtrl">
         <checkbox
           label="Postcards"
           v-model="selectedFilters"
@@ -72,8 +72,8 @@ const WithHeaderTemplate = (args, { argTypes }) => ({
   setup: () => ({ args }),
   template: `
     <div class="relative">
-      <LobButton @click.stop="open = !open" size="small">Filter by</LobButton>
-      <filter-content v-model:open="open">
+      <LobButton ref="filterContentCtrl" @click.stop="open = !open" size="small">Filter by</LobButton>
+      <filter-content v-model:open="open" :bound-element="$refs.filterContentCtrl">
         <template v-slot:header>
           <div class="text-center w-full">
             Filter By

--- a/src/components/FilterContent/FilterContent.vue
+++ b/src/components/FilterContent/FilterContent.vue
@@ -38,6 +38,10 @@ export default {
     open: {
       type: Boolean,
       default: false
+    },
+    boundElement: {
+      type: Object,
+      default: null
     }
   },
   emits: ['update:open'],
@@ -68,12 +72,18 @@ export default {
       }
     },
     onClickOutside ($event) {
-      if (typeof this.$refs.container !== 'undefined') {
+      if (this.$refs.container) {
         const clickOnTheContainer = this.$refs.container === $event.target;
         const clickOnChild = this.$refs.container && this.$refs.container.contains($event.target);
 
+        const clickToOpenElement = this.boundElement && (this.boundElement.$el || this.boundElement);
+        const clickOnBoundElement = clickToOpenElement && (clickToOpenElement === $event.target || clickToOpenElement.contains($event.target));
+
         if (!clickOnTheContainer && !clickOnChild) {
-          this.hide();
+          if (clickOnBoundElement) {
+            $event.stopPropagation();
+          }
+          this.hide($event);
         }
       }
     },

--- a/src/components/FilterContent/__tests__/FilterContent.spec.js
+++ b/src/components/FilterContent/__tests__/FilterContent.spec.js
@@ -34,6 +34,68 @@ describe('FilterContent', () => {
     expect(emittedEvent['update:open'][0][0]).toEqual(false);
   });
 
+  describe('without a bound element', () => {
+
+    const Component = {
+      components: { FilterContent },
+      template: `
+        <div>
+          <button @click="filterOpen = !filterOpen">button</button>
+          <filter-content v-model:open="filterOpen"><span>content</span></filter-content>
+        </div>
+      `,
+      data () {
+        return {
+          filterOpen: false
+        };
+      }
+    };
+
+    it('always bubbles the click event when the element mutation v-model:open is clicked', async () => {
+      const { getByText, findByText  } = render(Component);
+      const button = getByText('button');
+      await fireEvent.click(button);
+      await findByText('content');
+      await fireEvent.click(button);
+
+      const content = await findByText('content');
+      expect(content).toBeInTheDocument();
+    });
+
+  });
+
+  describe('with a bound element', () => {
+
+    const Component = {
+      components: { FilterContent },
+      template: `
+        <div>
+          <button ref="filterContentCtrl" @click="filterOpen = !filterOpen">button</button>
+          <filter-content v-model:open="filterOpen" :bound-element="$refs.filterContentCtrl"><span>content</span></filter-content>
+        </div>
+      `,
+      data () {
+        return {
+          filterOpen: false
+        };
+      }
+    };
+
+    it('does not bubble the click event when the element mutation v-model:open is clicked', async () => {
+      const { getByText, queryByText, findByText  } = render(Component);
+      const button = getByText('button');
+      await fireEvent.click(button);
+      await findByText('content');
+      await fireEvent.click(button);
+
+      await waitFor(() => {
+        const content = queryByText('content');
+        expect(content).not.toBeInTheDocument();
+      });
+    });
+
+  });
+
   describe('only one FilterContent can be open at a time', () => {
 
     const Component = {

--- a/src/components/FilterContent/__tests__/FilterContent.spec.js
+++ b/src/components/FilterContent/__tests__/FilterContent.spec.js
@@ -40,10 +40,10 @@ describe('FilterContent', () => {
       components: { FilterContent },
       template: `
         <div>
-          <button @click="filter1Open = true">button 1</button>
-          <filter-content v-model:open="filter1Open"><span>content 1</span></filter-content>
-          <button @click="filter2Open = true" data-testId="buttonToClick">button 2</button>
-          <filter-content v-model:open="filter2Open"><span>content 2</span></filter-content>
+          <button ref="buttonOne" @click="filter1Open = true">button 1</button>
+          <filter-content v-model:open="filter1Open" :bound-element="$refs.buttonOne"><span>content 1</span></filter-content>
+          <button ref="buttonTwo" @click="filter2Open = true" data-testId="buttonToClick">button 2</button>
+          <filter-content v-model:open="filter2Open" :bound-element="$refs.buttonTwo"><span>content 2</span></filter-content>
         </div>
       `,
       data () {


### PR DESCRIPTION
## JIRA

* Found while working on [DANG-276](https://lobsters.atlassian.net/browse/DANG-276)

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

Add a `boundElement` prop to the FilterContent component. When present, if the click event triggered by clicking outside the FilterContent component was from clicking on the `boundElement` the event will not be propagated so that the `v-model:open` doesn't get mutated twice (once from FilterContent.hide() and the other from the bubbled up click event)

<!--
## Screenshots
- before and after screenshots for features with visual changes
-->

<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
