### PR TITLE
Fix radio button focus/click causing view to jump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.73",
+  "version": "0.0.87",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "0.0.73",
+      "version": "0.0.87",
       "dependencies": {
         "core-js": "^3.6.5",
         "mitt": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.85",
+  "version": "0.0.87",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/RadioButton/RadioButton.mdx
+++ b/src/components/RadioButton/RadioButton.mdx
@@ -17,16 +17,33 @@ You can pass in the `v-model` prop to bind radio buttons to the parent component
 
 You can pass in a `@click` handler to trigger a custom function on click events. The `event` object will be emitted along with the `click` event.
 
-There is an option to pass a slot through as part of the label. In Lob's use case, this is to add an icon and a tooltip to further explain radio button choices.
+If nothing is provided in the slot, the label will be rendered by default. Alternatively, you can provide any sort of content to be rendered in place of the label.
 
 ```html
-<radio-button
+<RadioButton
   name="postcard-size"
   value="4x6"
   label="4x6"
   v-model="postcard.size"
   @click="handleClick"
 />
+```
+
+Example with slot that contains label and tooltip
+
+```html
+<RadioButton
+  name="postcard-size"
+  value="4x6"
+  label="4x6"
+  v-model="postcard.size"
+  @click="handleClick"
+>
+  <div class="flex">
+    {{ service.description }} <!-- this becomes the label -->
+    <Tooltip /> 
+  </div>
+</RadioButton>
 ```
 
 ## Props

--- a/src/components/RadioButton/RadioButton.vue
+++ b/src/components/RadioButton/RadioButton.vue
@@ -10,7 +10,7 @@
       :id="id"
       type="radio"
       :class="[
-        'm-0 p-0 w-0 h-0 opacity-0 mt-2',
+        'm-0 p-0 opacity-0 mt-2',
         { 'radio__input--error': error },
         { 'cursor-not-allowed': disabled || readonly }
       ]"
@@ -26,7 +26,7 @@
     <label
       :for="id"
       :class="[
-        'text-sm font-light relative flex ml-6',
+        'text-sm font-light relative flex ml-1.5',
         { 'cursor-not-allowed': disabled || readonly }
       ]"
     >
@@ -116,8 +116,8 @@ input {
     &::before {
       content: "";
       top: 3px;
+      left: -19px;
 
-      @apply -left-5;
       @apply absolute;
       @apply bg-transparent;
       @apply border-gray-100;
@@ -131,8 +131,8 @@ input {
 
     &::after {
       content: "";
-      left: -17px;
 
+      @apply -left-4;
       @apply top-1.5;
       @apply absolute;
       @apply h-2;

--- a/src/components/RadioButton/RadioButton.vue
+++ b/src/components/RadioButton/RadioButton.vue
@@ -115,9 +115,9 @@ input {
 
     &::before {
       content: "";
-      left: -20px;
       top: 3px;
 
+      @apply -left-5;
       @apply absolute;
       @apply bg-transparent;
       @apply border-gray-100;

--- a/src/components/RadioButton/RadioButton.vue
+++ b/src/components/RadioButton/RadioButton.vue
@@ -10,7 +10,7 @@
       :id="id"
       type="radio"
       :class="[
-        'absolute m-0 p-0 w-0 h-0 opacity-0 pointer-events-none mt-2',
+        'm-0 p-0 w-0 h-0 opacity-0 mt-2',
         { 'radio__input--error': error },
         { 'cursor-not-allowed': disabled || readonly }
       ]"
@@ -30,8 +30,9 @@
         { 'cursor-not-allowed': disabled || readonly }
       ]"
     >
-      {{ label }}
-      <slot />
+      <slot>
+        {{ label }}
+      </slot>
     </label>
   </div>
 </template>
@@ -107,32 +108,38 @@ export default {
 
 <style scoped lang="scss">
 input {
-  + label::before {
-    content: "";
-    left: -20px;
-
-    @apply absolute;
-    @apply bg-transparent;
-    @apply border-gray-100;
-    @apply border-solid;
-    @apply border;
-    @apply h-3.5;
+  + label {
+    @apply relative;
     @apply inline-block;
-    @apply rounded-full;
-    @apply top-1;
-    @apply w-3.5;
-  }
+    @apply cursor-pointer;
 
-  + label::after {
-    content: "";
-    left: -17px;
-    top: 7px;
+    &::before {
+      content: "";
+      left: -20px;
+      top: 3px;
 
-    @apply absolute;
-    @apply h-2;
-    @apply inline-block;
-    @apply rounded-full;
-    @apply w-2;
+      @apply absolute;
+      @apply bg-transparent;
+      @apply border-gray-100;
+      @apply border-solid;
+      @apply border;
+      @apply h-3.5;
+      @apply inline-block;
+      @apply rounded-full;
+      @apply w-3.5;
+    }
+
+    &::after {
+      content: "";
+      left: -17px;
+
+      @apply top-1.5;
+      @apply absolute;
+      @apply h-2;
+      @apply inline-block;
+      @apply rounded-full;
+      @apply w-2;
+    }
   }
 
   &:checked + label::after {


### PR DESCRIPTION
## Description

Absolute positioning on the input was causing the view to jump when a radio button was far enough down a page and was focused/clicked, so did the following:
* Removed absolute positioning
* Added/adjusted some small label styles
* Fixed psuedo element positioning
* Made label part of slot/the default to accommodate for optional tooltip icon positioning
* Removed `h-0`/`w-0` as that prevented default `required` tooltip from appearing

## Testing

This is a bit hard to test because it requires a few specific conditions to be true, but happy to hop on a quick call and demo if you'd like.
