### PR TITLE
DateInput will also accept null so that it can be blank for filters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.89",
+  "version": "0.0.95",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "0.0.89",
+      "version": "0.0.95",
       "dependencies": {
         "core-js": "^3.6.5",
         "date-fns": "^2.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.94",
+  "version": "0.0.95",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/DateInput/DateInput.vue
+++ b/src/components/DateInput/DateInput.vue
@@ -37,7 +37,7 @@ export default {
       required: true
     },
     modelValue: {
-      type: Date,
+      type: [Date, null],
       required: true
     },
     open: {


### PR DESCRIPTION
## Description

DateInput now accepts [Date, null] as modelValue, so that it can be null/empty/blank for using in the filters

the modelValue prop is required so in theory this won't affect any of the existing implementation