### PR TITLE
Revert "DateInput will also accept null so that it can be blank for f…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.94",
+  "version": "0.0.97",
   "engines": {
     "node": "14.16.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.95",
+  "version": "0.0.94",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/DateInput/DateInput.vue
+++ b/src/components/DateInput/DateInput.vue
@@ -37,7 +37,7 @@ export default {
       required: true
     },
     modelValue: {
-      type: [Date, null],
+      type: Date,
       required: true
     },
     open: {


### PR DESCRIPTION
…ilters (#135)"

This reverts commit 15b1e8e6eb424cba3ca4ed9200acf8419cca97a9 because the dashboard does not like the possibility of a null in the DateInput. I'll look at other ways to default this to blank for the filter.