### PR TITLE
fix borders on non-white background with backgroundColor prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.105",
+  "version": "0.0.106",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/Stepper/Stepper.stories.js
+++ b/src/components/Stepper/Stepper.stories.js
@@ -22,7 +22,7 @@ const Template = (args) => ({
   components: { Stepper, StepperItem },
   setup: () => ({ args }),
   template: `
-  <div class="bg-white-300 py-8">
+  <div class="bg-white-300" style="padding: 2rem 0;">
     <Stepper>
       <StepperItem position="first" :finished="true" :alignment="args.alignment" :text-vertical-align="args.textVerticalAlign" backgroundColor="${colors.white['300']}">
         <div class="text-center">

--- a/src/components/Stepper/Stepper.stories.js
+++ b/src/components/Stepper/Stepper.stories.js
@@ -24,7 +24,6 @@ const Template = (args) => ({
   template: `
   <div class="bg-white-300 py-8">
     <Stepper>
-    <template v-slot="{ alignment, textVerticalAlign }">
       <StepperItem position="first" :finished="true" :alignment="args.alignment" :text-vertical-align="args.textVerticalAlign" backgroundColor="${colors.white['300']}">
         <div class="text-center">
           Finished

--- a/src/components/Stepper/Stepper.stories.js
+++ b/src/components/Stepper/Stepper.stories.js
@@ -22,28 +22,31 @@ const Template = (args) => ({
   components: { Stepper, StepperItem },
   setup: () => ({ args }),
   template: `
+  <div class="bg-white-300 py-8">
     <Stepper>
-      <StepperItem position="first" :finished="true" :alignment="args.alignment" :text-vertical-align="args.textVerticalAlign">
+    <template v-slot="{ alignment, textVerticalAlign }">
+      <StepperItem position="first" :finished="true" :alignment="args.alignment" :text-vertical-align="args.textVerticalAlign" backgroundColor="${colors.white['300']}">
         <div class="text-center">
           Finished
         </div>
       </StepperItem>
-      <StepperItem :active="true" :alignment="args.alignment" :text-vertical-align="args.textVerticalAlign">
+      <StepperItem :active="true" :alignment="args.alignment" :text-vertical-align="args.textVerticalAlign" backgroundColor="${colors.white['300']}">
         <div class="text-center">
           Active
         </div>
       </StepperItem>
-      <StepperItem color="${colors.error}" :alignment="args.alignment" :text-vertical-align="args.textVerticalAlign">
+      <StepperItem color="${colors.error}" :alignment="args.alignment" :text-vertical-align="args.textVerticalAlign" backgroundColor="${colors.white['300']}">
         <div class="text-center">
           Error
         </div>
       </StepperItem>
-      <StepperItem position="last" color="${colors.gray['100']}" :alignment="args.alignment" :text-vertical-align="args.textVerticalAlign">
+      <StepperItem position="last" color="${colors.gray['100']}" :alignment="args.alignment" :text-vertical-align="args.textVerticalAlign" backgroundColor="${colors.white['300']}">
         <div class="text-center">
           Unfinished
         </div>
       </StepperItem>
     </Stepper>
+    </div>
     `
 });
 

--- a/src/components/Stepper/StepperItem.vue
+++ b/src/components/Stepper/StepperItem.vue
@@ -7,30 +7,20 @@
       {'items-end': alignRight}
     ]"
   >
-    <div
-      :style="`color: ${backgroundColor}`"
-    >
-      <div
-        :class="[
-          'w-16 md:w-32 min-w-max flex flex-col relative border-current',
-          {'items-start': alignLeft},
-          {'items-center': alignCenter},
-          {'items-end': alignRight},
-          {'border-none': alignLeft && last},
-          {'half-border': alignCenter},
-          {'half-border-right': first},
-          {'half-border-left': last},
-          {'half-border-bottom': (first || last) && textBottom},
-          {'half-border-top': (first || last) && textTop},
-          {'border-none': alignRight && first},
-          {'border-dashed ': dashedBorder},
-          { 'border-t ': textBottom },
-          { 'border-b': textTop }
-
-        ]"
-        :style="`border-color: ${borderColor || color}`"
-      />
-    </div>
+    <StepperItemBorder
+      v-if="textBottom"
+      :background-color="backgroundColor"
+      :align-left="alignLeft"
+      :align-center="alignCenter"
+      :align-right="alignRight"
+      :first="first"
+      :last="last"
+      :text-bottom="textBottom"
+      :text-top="textTop"
+      :dashed-border="dashedBorder"
+      :border-color="borderColor"
+      :color="color"
+    />
     <div
       :class="[
         'w-16 md:w-32 min-w-max  flex flex-col relative',
@@ -71,11 +61,26 @@
         <slot />
       </div>
     </div>
+    <StepperItemBorder
+      v-if="textTop"
+      :background-color="backgroundColor"
+      :align-left="alignLeft"
+      :align-center="alignCenter"
+      :align-right="alignRight"
+      :first="first"
+      :last="last"
+      :text-bottom="textBottom"
+      :text-top="textTop"
+      :dashed-border="dashedBorder"
+      :border-color="borderColor"
+      :color="color"
+    />
   </div>
 </template>
 
 <script>
 import { Check } from '../Icons';
+import StepperItemBorder from './StepperItemBorder.vue';
 import { config } from 'tailwind-plugin-lob';
 
 const { theme } = config;
@@ -83,7 +88,7 @@ const { colors } = theme;
 
 export default {
   name: 'StepperItem',
-  components: { Check },
+  components: { Check, StepperItemBorder },
   props: {
     position: {
       type: String,
@@ -111,7 +116,7 @@ export default {
     },
     backgroundColor: {
       type: String,
-      default: null
+      default: 'transparent'
     },
     active: {
       type: Boolean,
@@ -152,32 +157,3 @@ export default {
 };
 </script>
 
-<style scoped lang="scss">
-  .half-border::after {
-    @apply p-0;
-    @apply m-0;
-    @apply block;
-    @apply w-1/2;
-    @apply h-1;
-    @apply bg-current;
-    @apply absolute;
-
-    content: "";
-  }
-
-  .half-border-left::after {
-    @apply right-0;
-  }
-
-  .half-border-right::after {
-    @apply left-0;
-  }
-
-  .half-border-bottom::after {
-    @apply -top-1;
-  }
-
-  .half-border-top::after {
-    @apply top-12;
-  }
-</style>

--- a/src/components/Stepper/StepperItem.vue
+++ b/src/components/Stepper/StepperItem.vue
@@ -4,51 +4,72 @@
       'w-16 md:w-32 min-w-max flex flex-col relative border-current',
       {'items-start': alignLeft},
       {'items-center': alignCenter},
-      {'items-end': alignRight},
-      {'border-none': alignLeft && last},
-      {'half-border': alignCenter},
-      {'half-border-right': first},
-      {'half-border-left': last},
-      {'half-border-bottom': (first || last) && textBottom},
-      {'half-border-top': (first || last) && textTop},
-      {'border-none': alignRight && first},
-      {'border-dashed ': dashedBorder},
-      { 'border-t ': textBottom },
-      { 'border-b': textTop }
-
+      {'items-end': alignRight}
     ]"
-    :style="`border-color: ${borderColor || color}`"
   >
     <div
-      v-if="textTop"
-      class="mb-6"
+      :style="`color: ${backgroundColor}`"
     >
-      <slot />
+      <div
+        :class="[
+          'w-16 md:w-32 min-w-max flex flex-col relative border-current',
+          {'items-start': alignLeft},
+          {'items-center': alignCenter},
+          {'items-end': alignRight},
+          {'border-none': alignLeft && last},
+          {'half-border': alignCenter},
+          {'half-border-right': first},
+          {'half-border-left': last},
+          {'half-border-bottom': (first || last) && textBottom},
+          {'half-border-top': (first || last) && textTop},
+          {'border-none': alignRight && first},
+          {'border-dashed ': dashedBorder},
+          { 'border-t ': textBottom },
+          { 'border-b': textTop }
+
+        ]"
+        :style="`border-color: ${borderColor || color}`"
+      />
     </div>
     <div
       :class="[
-        'z-10 rounded-full w-5 h-5 absolute border border-transparent bg-white',
-        { '!border-current': active },
-        { '-top-2.5': textBottom },
-        { 'top-10': textTop }
+        'w-16 md:w-32 min-w-max  flex flex-col relative',
+        {'items-start': alignLeft},
+        {'items-center': alignCenter},
+        {'items-end': alignRight}
       ]"
-      :style="`color: ${color}`"
     >
       <div
-        class="rounded-full w-3 h-3 absolute bg-current"
-        style="left: 0.1875rem; top: 0.1875rem; color: ${color};"
+        v-if="textTop"
+        class="mb-6"
       >
-        <check
-          v-if="finished"
-          class="w-2 absolute top-0.5 left-0.5 z-20 text-white"
-        />
+        <slot />
       </div>
-    </div>
-    <div
-      v-if="textBottom"
-      class="mt-6"
-    >
-      <slot />
+      <div
+        :class="[
+          'z-10 rounded-full w-5 h-5 absolute border border-transparent bg-white',
+          { '!border-current': active },
+          { '-top-2.5': textBottom },
+          { 'top-10': textTop }
+        ]"
+        :style="`color: ${color}`"
+      >
+        <div
+          class="rounded-full w-3 h-3 absolute bg-current"
+          style="left: 0.1875rem; top: 0.1875rem; color: ${color};"
+        >
+          <check
+            v-if="finished"
+            class="w-2 absolute top-0.5 left-0.5 z-20 text-white"
+          />
+        </div>
+      </div>
+      <div
+        v-if="textBottom"
+        class="mt-6"
+      >
+        <slot />
+      </div>
     </div>
   </div>
 </template>
@@ -85,6 +106,10 @@ export default {
     },
     // will default to color if not provided
     borderColor: {
+      type: String,
+      default: null
+    },
+    backgroundColor: {
       type: String,
       default: null
     },
@@ -134,7 +159,7 @@ export default {
     @apply block;
     @apply w-1/2;
     @apply h-1;
-    @apply bg-white;
+    @apply bg-current;
     @apply absolute;
 
     content: "";

--- a/src/components/Stepper/StepperItem.vue
+++ b/src/components/Stepper/StepperItem.vue
@@ -164,6 +164,5 @@ export default {
   @screen md {
     min-width: 8rem;
   }
-
 }
 </style>

--- a/src/components/Stepper/StepperItem.vue
+++ b/src/components/Stepper/StepperItem.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     :class="[
-      'w-16 md:w-32 min-w-max flex flex-col relative border-current',
+      'stepper-item flex flex-col relative border-current',
       {'items-start': alignLeft},
       {'items-center': alignCenter},
       {'items-end': alignRight}
@@ -37,12 +37,12 @@
       </div>
       <div
         :class="[
-          'z-10 rounded-full w-5 h-5 absolute border border-transparent bg-white',
+          'z-10 rounded-full w-5 h-5 absolute border border-transparent',
           { '!border-current': active },
           { '-top-2.5': textBottom },
           { 'top-10': textTop }
         ]"
-        :style="`color: ${color}`"
+        :style="`color: ${color}; background-color: ${backgroundColor}`"
       >
         <div
           class="rounded-full w-3 h-3 absolute bg-current"
@@ -116,7 +116,7 @@ export default {
     },
     backgroundColor: {
       type: String,
-      default: 'transparent'
+      default: colors.white.DEFAULT
     },
     active: {
       type: Boolean,
@@ -157,3 +157,13 @@ export default {
 };
 </script>
 
+<style scoped lang="scss">
+.stepper-item {
+  min-width: 4rem;
+
+  @screen md {
+    min-width: 8rem;
+  }
+
+}
+</style>

--- a/src/components/Stepper/StepperItemBorder.vue
+++ b/src/components/Stepper/StepperItemBorder.vue
@@ -1,0 +1,112 @@
+<template>
+  <div
+    :style="`color: ${backgroundColor}`"
+  >
+    <div
+      :class="[
+        'w-16 md:w-32 min-w-max flex flex-col relative border-current',
+        {'items-start': alignLeft},
+        {'items-center': alignCenter},
+        {'items-end': alignRight},
+        {'border-none': alignLeft && last},
+        {'half-border': alignCenter},
+        {'half-border-right': first},
+        {'half-border-left': last},
+        {'half-border-bottom': (first || last) && textBottom},
+        {'half-border-top': (first || last) && textTop},
+        {'border-none': alignRight && first},
+        {'border-dashed ': dashedBorder},
+        { 'border-t ': textBottom },
+        { 'border-b': textTop }
+
+      ]"
+      :style="`border-color: ${borderColor || color}`"
+    />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'StepperItemBorder',
+  props: {
+    backgroundColor: {
+      type: String,
+      required: true
+    },
+    borderColor: {
+      type: String,
+      required: true
+    },
+    color: {
+      type: String,
+      required: true
+    },
+    alignLeft: {
+      type: Boolean,
+      required: true
+    },
+    alignCenter: {
+      type: Boolean,
+      required: true
+    },
+    alignRight: {
+      type: Boolean,
+      required: true
+    },
+    first: {
+      type: Boolean,
+      required: true
+    },
+    last: {
+      type: Boolean,
+      required: true
+    },
+    textBottom: {
+      type: Boolean,
+      required: true
+    },
+    textTop: {
+      type: Boolean,
+      required: true
+    },
+    dashedBorder: {
+      type: Boolean,
+      required: true
+    }
+  }
+};
+</script>
+
+<style scoped lang="scss">
+  .half-border::after {
+    @apply p-0;
+    @apply m-0;
+    @apply block;
+    @apply w-1/2;
+    @apply h-1;
+    @apply bg-current;
+    @apply absolute;
+
+    content: "";
+  }
+
+  .half-border.border-b:not(.half-border-left):not(.half-border-right):after {
+    @apply -top-3;
+  }
+
+  .half-border-left::after {
+    @apply right-0;
+  }
+
+  .half-border-right::after {
+    @apply left-0;
+  }
+
+  .half-border-bottom::after {
+    @apply -top-1;
+  }
+
+  .half-border-top::after {
+    @apply top-0;
+  }
+</style>

--- a/src/components/Stepper/StepperItemBorder.vue
+++ b/src/components/Stepper/StepperItemBorder.vue
@@ -1,10 +1,11 @@
 <template>
   <div
+    class="w-full"
     :style="`color: ${backgroundColor}`"
   >
     <div
       :class="[
-        'w-16 md:w-32 min-w-max flex flex-col relative border-current',
+        'stepper-item-border flex flex-col relative border-current',
         {'items-start': alignLeft},
         {'items-center': alignCenter},
         {'items-end': alignRight},
@@ -78,6 +79,14 @@ export default {
 </script>
 
 <style scoped lang="scss">
+.stepper-item-border {
+  min-width: 4rem;
+
+  @screen md {
+    min-width: 8rem;
+  }
+}
+
   .half-border::after {
     @apply p-0;
     @apply m-0;

--- a/src/components/Stepper/StepperItemBorder.vue
+++ b/src/components/Stepper/StepperItemBorder.vue
@@ -87,35 +87,35 @@ export default {
   }
 }
 
-  .half-border::after {
-    @apply p-0;
-    @apply m-0;
-    @apply block;
-    @apply w-1/2;
-    @apply h-1;
-    @apply bg-current;
-    @apply absolute;
+.half-border::after {
+  @apply p-0;
+  @apply m-0;
+  @apply block;
+  @apply w-1/2;
+  @apply h-1;
+  @apply bg-current;
+  @apply absolute;
 
-    content: "";
-  }
+  content: "";
+}
 
-  .half-border.border-b:not(.half-border-left):not(.half-border-right):after {
-    @apply -top-3;
-  }
+.half-border.border-b:not(.half-border-left):not(.half-border-right)::after {
+  @apply -top-3;
+}
 
-  .half-border-left::after {
-    @apply right-0;
-  }
+.half-border-left::after {
+  @apply right-0;
+}
 
-  .half-border-right::after {
-    @apply left-0;
-  }
+.half-border-right::after {
+  @apply left-0;
+}
 
-  .half-border-bottom::after {
-    @apply -top-1;
-  }
+.half-border-bottom::after {
+  @apply -top-1;
+}
 
-  .half-border-top::after {
-    @apply top-0;
-  }
+.half-border-top::after {
+  @apply top-0;
+}
 </style>


### PR DESCRIPTION
## JIRA

* N/A

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

If a stepper is not on a white background, we have to do some fancy CSS magic to set the background color for our half borders.


## Screenshots
Before
![image](https://user-images.githubusercontent.com/9774690/130695825-d58edc42-5d27-48cd-bfb3-434af8e82e87.png)

After
![image](https://user-images.githubusercontent.com/9774690/130695776-48d7221d-6500-44a1-bc13-aa6b851579ea.png)


<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
