### PR TITLE
Dang 429/breadcrumb bugs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
     # You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.
     docker:
       - image: cimg/node:14.16.1-browsers
+    resource_class: large
     # Then run your tests!
     steps:
       # Checkout the code as the first step.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.116",
+  "version": "0.0.119",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/Breadcrumb/Breadcrumb.mdx
+++ b/src/components/Breadcrumb/Breadcrumb.mdx
@@ -15,7 +15,13 @@ Include a breadcrumb in a layout or inside any component where you want to rende
 
 The breadcrumb component is route aware and will render a link for each matched route. Refer to [Vue's documentation](https://router.vuejs.org/guide/essentials/nested-routes.html) for information on how to configure your router for nested routing.
 
-The displayed link text will use the route's name (refer to [Vue's documentation for named routes](https://router.vuejs.org/guide/essentials/named-routes.html)) or the last segment in the path if the route is not named.
+The displayed link text is dynamic. If you provide a `displayName` to the route's `meta` fields, then that will be used. If you provide `useParamsForDisplay` and the route has params, the params will be resolved and display (for example `:id` will display the actual id). If neither of those meta fields are provided, the link text will use the route's name (refer to [Vue's documentation for named routes](https://router.vuejs.org/guide/essentials/named-routes.html)) or the last segment in the path if the route is not named.
+
+TLDR; the priority of displayed link text is as follows
+1. `$route.meta.displayName`
+2. the resolved param if `$route.meta.useParamsForDisplay`
+3. `$route.name`
+4. the last segment of `$route.path`
 
 You'll need to provide a `startName` to tell the component what to name the root route. If you want to include an icon at the start of your breadcrumbs, include an `iconSrc`. 
 

--- a/src/components/Breadcrumb/Breadcrumb.stories.js
+++ b/src/components/Breadcrumb/Breadcrumb.stories.js
@@ -8,7 +8,7 @@ export default {
   title: 'Components/Breadcrumb',
   component: Breadcrumb,
   decorators: [
-    routeDecorator('/envelopes/create', [
+    routeDecorator('/envelopes/env_f488a53a4801c87f5', [
       {
         path: '/',
         component: {
@@ -18,21 +18,27 @@ export default {
       {
         path: '/envelopes',
         component: {
-          template: '<div><h1>Letters</h1><router-view /></div>'
+          template: '<div><h1>Envelopes</h1><router-view /></div>'
         },
         children: [
           {
             path: '',
-            name: 'Envelopes',
+            name: 'EnvelopesList',
             component: {
               template: routeTemplate('envelopes')
+            },
+            meta: {
+              displayName: 'Envelopes'
             }
           },
           {
-            path: 'create',
-            name: 'Create Envelope',
+            path: ':id',
+            name: 'ViewEnvelope',
             component: {
-              template: routeTemplate('create')
+              template: routeTemplate('view')
+            },
+            meta: {
+              useParamsForDisplay: true
             }
           }
         ]

--- a/src/components/Breadcrumb/__tests__/Breadcrumb.spec.js
+++ b/src/components/Breadcrumb/__tests__/Breadcrumb.spec.js
@@ -23,15 +23,29 @@ const routes = [
     children: [
       {
         path: 'create',
-        name: 'Create envelopes',
+        name: 'Create',
         component: {
           template: '<div>create</div>'
+        },
+        meta: {
+          displayName: 'Create Envelope'
         }
       },
       {
-        path: 'edit',
+        path: ':id/edit',
+        name: 'Edit Envelope',
         component: {
           template: '<div>edit</div>'
+        }
+      },
+      {
+        path: ':id',
+        name: 'View Envelope',
+        component: {
+          template: '<div>view</div>'
+        },
+        meta: {
+          useParamsForDisplay: true
         }
       }
     ]
@@ -86,24 +100,64 @@ describe('Breadcrumb', () => {
     expect(links[2]).toHaveClass('router-link-active');
   });
 
-  it('renders the text title-cased when there\'s a name', async () => {
-    const props = initialProps;
-    const { queryByText } = renderComponent({ props });
-    router.push('/envelopes/create');
-    await router.isReady();
+  describe('when a display name is provided', () => {
 
-    const navLink = queryByText('Create Envelopes');
-    expect(navLink).toBeInTheDocument();
+    it('renders the correct text title-cased', async () => {
+      const props = initialProps;
+      const { getByText } = renderComponent({ props });
+      router.push('/envelopes/create');
+      await router.isReady();
+
+      const navLink = getByText('Create Envelope');
+      expect(navLink).toBeInTheDocument();
+    });
+
   });
 
-  it('renders the text title-cased when there\'s not a name', async () => {
-    const props = initialProps;
-    const { queryByText } = renderComponent({ props });
-    router.push('/envelopes/edit');
-    await router.isReady();
+  describe('when there is not a display name', () => {
 
-    const navLink = queryByText('Edit');
-    expect(navLink).toBeInTheDocument();
+    describe('when useParamsForDisplay is true', () => {
+
+      it('renders the correct text title-cased', async () => {
+        const props = initialProps;
+        const { getByText } = renderComponent({ props });
+        router.push('/envelopes/23');
+        await router.isReady();
+
+        const navLink = getByText('23');
+        expect(navLink).toBeInTheDocument();
+      });
+
+    });
+
+    describe('when useParamsForDisplay is false', () => {
+
+      it('renders the correct text title-cased', async () => {
+        const props = initialProps;
+        const { getByText } = renderComponent({ props });
+        router.push('/envelopes/23/edit');
+        await router.isReady();
+
+        const navLink = getByText('Edit Envelope');
+        expect(navLink).toBeInTheDocument();
+      });
+
+    });
+
+  });
+
+  describe('when the path portion has a param', () => {
+
+    it('interpolates the param into the route path', async () => {
+      const props = initialProps;
+      const { getByText } = renderComponent({ props });
+      router.push('/envelopes/23');
+      await router.isReady();
+
+      const navLink = getByText('23');
+      expect(navLink).toHaveAttribute('href', '/envelopes/23');
+    });
+
   });
 
 });

--- a/src/components/Link/Link.stories.js
+++ b/src/components/Link/Link.stories.js
@@ -10,6 +10,7 @@ export default {
     routeDecorator('/', [
       {
         path: '/internal',
+        name: 'InternalLink',
         component: {
           template: routeTemplate('internal')
         }

--- a/src/components/Link/Link.vue
+++ b/src/components/Link/Link.vue
@@ -35,7 +35,7 @@ export default {
       }
     },
     to: {
-      type: String,
+      type: [String, Object],
       default: ''
     },
     label: {
@@ -65,7 +65,7 @@ export default {
     },
     isExternal () {
       const protocolRelativePattern = /^https?:\/\/|^\/\//i;
-      return protocolRelativePattern.test(this.to);
+      return typeof this.to === 'string' && protocolRelativePattern.test(this.to);
     },
     tag () {
       if (this.isExternal) {

--- a/src/components/Link/__tests__/Link.spec.js
+++ b/src/components/Link/__tests__/Link.spec.js
@@ -11,7 +11,7 @@ const initialProps = {
 const routes = [
   { path: '', component: { template: '<div></div>' } },
   { path: '/', component: { template: '<div>/</div>' } },
-  { path: '/settings', component: { template: '<div>settings</div>' } }
+  { path: '/settings', name: 'Settings', component: { template: '<div>settings</div>' } }
 ];
 const router = createRouter({
   history: createMemoryHistory(),
@@ -29,8 +29,19 @@ const renderComponent = async (options) => {
 
 describe('Link', () => {
 
-  it('renders correctly when an internal link', async () => {
+  it('renders correctly when an internal link with a string', async () => {
     const props = initialProps;
+    const { queryByRole } = await renderComponent({ props });
+
+    const link = queryByRole('link');
+    expect(link).toBeInTheDocument();
+  });
+
+  it('renders correctly when an internal link with an object', async () => {
+    const props = {
+      ...initialProps,
+      to: { name: 'Settings' }
+    };
     const { queryByRole } = await renderComponent({ props });
 
     const link = queryByRole('link');


### PR DESCRIPTION
## JIRA

* https://lobsters.atlassian.net/browse/DANG-429

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

This PR resolves the following bugs and desired behaviors.
- When viewing a specific resource, like `postcards/some-postcard-id`, if one clicks the breadcrumb link of it (like Postcards > Postcard), the route updates wrongly, and tries to redirect to something like `/postcards/:id`.
- We need to be able to translate the breadcrumb display text while keeping consistent route names
- Sometimes we may want to display dynamic breadcrumb text depending on the route params (e.g. resolve the id so we can display it in the breadcrumb)
- We want our LobLink to accept an object in case we want to use named routes and route params


## Screenshots
![image](https://user-images.githubusercontent.com/9774690/133324662-9c615535-17a8-4672-8a31-c1edff9ea1b8.png)



<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
