### PR TITLE
Add class prop to Subnav, SubnavItem improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.116",
+  "version": "0.0.118",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/Subnavigation/Subnavigation.mdx
+++ b/src/components/Subnavigation/Subnavigation.mdx
@@ -20,10 +20,12 @@ The subnavigation component is used for displaying a secondary, horizontal navig
 
 The subnavigation renders a semantic `nav` element with a `ul`. It is made to work with the `subnavigation-item` component. However, you can also write custom components for its slot as long as the root element is an `li` (for accessibility).
 
+It accepts an optional `ulClass` prop. For Lob's purposes, this is so that we can make the subnavigivation full-width, however, you may pass in any valid Tailwind class(es) to apply to the `ul` element.
+
 Example of using this component in a template:
 
 ```html
-<subnavigation v-bind="args">
+<subnavigation>
   <subnavigation-item title="Account" to="/account" />
   <subnavigation-item title="API Keys" to="/api-keys" />
   <subnavigation-item title="Payment" to="/payment" />

--- a/src/components/Subnavigation/Subnavigation.vue
+++ b/src/components/Subnavigation/Subnavigation.vue
@@ -1,6 +1,6 @@
 <template>
   <nav>
-    <ul class="flex pb-3.5 border-b border-gray-100">
+    <ul :class="`flex pb-3.5 border-b border-gray-100 ${ulClass}`">
       <slot />
     </ul>
   </nav>
@@ -8,6 +8,12 @@
 
 <script>
 export default {
-  name: 'Subnavigation'
+  name: 'Subnavigation',
+  props: {
+    ulClass: {
+      type: String,
+      default: ''
+    }
+  }
 };
 </script>

--- a/src/components/Subnavigation/SubnavigationItem.vue
+++ b/src/components/Subnavigation/SubnavigationItem.vue
@@ -2,20 +2,23 @@
   <li
     class="list-none mr-12"
   >
-    <router-link
+    <LobLink
       :to="to"
-      class="relative pb-4"
-      exact-active-class="lob-active-border"
+      class="relative pb-4 no-underline text-black font-light"
+      exact-active-class="lob-active-border font-normal"
       data-testid="subnav-item"
     >
       {{ title }}
-    </router-link>
+    </LobLink>
   </li>
 </template>
 
 <script>
+import LobLink from '../Link/Link';
+
 export default {
   name: 'SubnavigationItem',
+  components: { LobLink },
   props: {
     title: {
       type: String,


### PR DESCRIPTION
## JIRA

* N/A, discovered/needed while working on [DANG-431](https://lobsters.atlassian.net/browse/DANG-431)

## Description

* Gives `Subnavigation` an optional `ulClass` prop so that we can set `w-full` and `justify-between` to make the component expand/collapse to the full page width
* Replaces `router-link` in `SubnavigationItem` with `LobLink` component
* Makes `SubnavigationItem` look much closer to the designs

## Screenshots

![Screen Shot 2021-09-14 at 2 21 50 PM](https://user-images.githubusercontent.com/20443660/133328295-b1a23532-685b-4361-a8ac-398ea275410b.png)
