### PR TITLE
fix bug setting main nav child active for children routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.120",
+  "version": "0.0.121",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/MainNavigation/MainNavigation.stories.js
+++ b/src/components/MainNavigation/MainNavigation.stories.js
@@ -46,7 +46,15 @@ export default {
         path: '/postcards',
         component: {
           template: routeTemplate('postcards')
-        }
+        },
+        children: [
+          {
+            path: ':id',
+            component: {
+              template: routeTemplate('view postcard')
+            }
+          }
+        ]
       },
       {
         path: '/letters',

--- a/src/components/MainNavigation/MainNavigationChildItem.vue
+++ b/src/components/MainNavigation/MainNavigationChildItem.vue
@@ -6,19 +6,22 @@
     ]"
     data-testid="nav-child-item"
   >
-    <router-link
+    <LobLink
       :to="to"
       class="w-full py-1 pl-8 overflow-hidden text-gray-500 focus:outline-none focus:ring-2 focus:ring-primary-100 focus:border-transparent"
       @click.stop="handleNavigation"
     >
       {{ title }}
-    </router-link>
+    </LobLink>
   </li>
 </template>
 
 <script>
+import LobLink from '../Link/Link';
+
 export default {
   name: 'MainNavigationChildItem',
+  components: { LobLink },
   props: {
     title: {
       type: String,
@@ -32,7 +35,7 @@ export default {
   emits: ['nav'],
   computed: {
     active () {
-      return this.$route.path === this.to;
+      return this.$route.path.includes(this.to);
     }
   },
   methods: {

--- a/src/components/MainNavigation/MainNavigationItem.vue
+++ b/src/components/MainNavigation/MainNavigationItem.vue
@@ -46,8 +46,11 @@
 </template>
 
 <script>
+import LobLink from '../Link/Link';
+
 export default {
   name: 'MainNavigationItem',
+  components: { LobLink },
   props: {
     title: {
       type: String,
@@ -89,7 +92,7 @@ export default {
       return Boolean(this.$slots.default);
     },
     tag () {
-      return this.to ? 'router-link' : 'button';
+      return this.to ? 'LobLink' : 'button';
     },
     clickEvent () {
       return !this.to ? 'click' : null;

--- a/src/components/MainNavigation/__tests__/MainNavigationChildItem.spec.js
+++ b/src/components/MainNavigation/__tests__/MainNavigationChildItem.spec.js
@@ -8,8 +8,11 @@ const initialProps = {
   to: '/overview'
 };
 const routes = [
-  { path: '/overview', component: { template: '<div>Overview</div>' } },
-  { path: '/about', component: { template: '<div>About</div>' } },
+  {
+    path: '/overview',
+    component: { template: '<div>Overview</div>' },
+    children: [{ path: 'about', component: { template: '<div>About</div>' } }]
+  },
   { path: '/', component: { template: '<div>Home</div>' } }
 ];
 const router = createRouter({
@@ -41,8 +44,19 @@ describe('Main Navigation Child Item', () => {
     const props = initialProps;
 
     const { queryByTestId } = renderComponent({ props });
+    router.push('/overview/about');
+    await router.isReady();
+
+    const navItem = queryByTestId('nav-child-item');
+    expect(navItem).toHaveClass('font-medium bg-white-300 rounded-l-full');
+  });
+
+  it('adds the correct classes when the item is exact active', async () => {
+    const props = initialProps;
     router.push('/overview');
     await router.isReady();
+
+    const { queryByTestId } = renderComponent({ props });
 
     const navItem = queryByTestId('nav-child-item');
     expect(navItem).toHaveClass('font-medium bg-white-300 rounded-l-full');


### PR DESCRIPTION
## JIRA

* https://lobsters.atlassian.net/browse/DANG-322

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

When the user was on a route like `/postcards/psc_ls094uwel98df`, the Postcards child nav item was not active. This PR fixes that bug and uses LobLinks instead of router-links (similar to the change Beth made in Subnavigation recently)

<!--
## Screenshots
- before and after screenshots for features with visual changes
-->

<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
