### PR TITLE
Switch group style

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.124",
+  "version": "0.0.125",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/Switch/SwitchGroup.vue
+++ b/src/components/Switch/SwitchGroup.vue
@@ -5,7 +5,7 @@
     <legend :class="['text-sm font-normal normal-case tracking-normal text-gray-500 mb-1 border-b-0', {'sr-only': srOnlyLegend}]">
       {{ legend }}
     </legend>
-    <div class="shadow flex p-1 bg-white rounded">
+    <div class="shadow flex flex-wrap p-1 bg-white rounded">
       <slot />
     </div>
   </fieldset>

--- a/src/components/Switch/SwitchGroup.vue
+++ b/src/components/Switch/SwitchGroup.vue
@@ -5,7 +5,7 @@
     <legend :class="['text-sm font-normal normal-case tracking-normal text-gray-500 mb-1 border-b-0', {'sr-only': srOnlyLegend}]">
       {{ legend }}
     </legend>
-    <div class="shadow flex flex-wrap p-1 bg-white rounded">
+    <div :class="['shadow flex flex-wrap p-1 bg-white rounded', { 'justify-center': center }]">
       <slot />
     </div>
   </fieldset>
@@ -20,6 +20,10 @@ export default {
       required: true
     },
     srOnlyLegend: {
+      type: Boolean,
+      default: false
+    },
+    center: {
       type: Boolean,
       default: false
     }


### PR DESCRIPTION
## JIRA

* N/A

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

By adding `flex-wrap` to the div containing our switch items, we can control the width of the parent via a `class` prop and if it constrains the width, things will wrap nicely without overflowing. If we don't constrain the width, then it's all good and will look the same as normal.

Also added prop for conditionally choosing to center items.

<!--
## Screenshots
- before and after screenshots for features with visual changes
-->

<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
