### PR TITLE
Dang 445/tootlip icon in label

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.127",
+  "version": "0.0.128",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/Dropdown/Dropdown.stories.js
+++ b/src/components/Dropdown/Dropdown.stories.js
@@ -1,6 +1,8 @@
 import Dropdown from './Dropdown.vue';
 import mdx from './Dropdown.mdx';
 
+import LobLabel from '@/components/LobLabel/LobLabel.vue';
+import Tooltip from '@/components/Tooltip/Tooltip.vue';
 import { Eye } from '@/components/Icons';
 
 export default {
@@ -282,24 +284,36 @@ WithOptGroups.args = {
   ]
 };
 
-const IconTemplate = (args, { argTypes }) => ({
+const moonVModel = 'Ganymede';
+
+const WithTooltipTemplate = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
-  components: {  Dropdown, Eye },
-  data: () => ({ vModel }),
+  components: {  Dropdown, Eye, LobLabel, Tooltip },
+  data: () => ({ moonVModel }),
   setup: () => ({ args }),
   template: `
-    <dropdown v-bind="args" v-model="vModel">
-      <template v-slot:iconRight>
-        <eye class="w-5 h-5" />
+    <LobLabel
+      label="Favorite Galilean Moon"
+      labelFor="galilean-moons"
+    >
+      <template v-slot:tooltip>
+        <Tooltip>
+          <template #trigger>
+            <Eye class="w-5 h-5" />
+          </template>
+          <template #content>
+            Tough choice, I know!
+          </template>      
+        </Tooltip>
       </template>
-    </dropdown>
+    </LobLabel>
+    <dropdown v-bind="args" v-model="moonVModel" />
   `
 });
 
-export const WithIcon = IconTemplate.bind({});
-WithIcon.args = {
+export const WithTooltip = WithTooltipTemplate.bind({});
+WithTooltip.args = {
   id: 'galilean-moons',
-  label: 'Destination',
   options: [
     'Io',
     'Europa',

--- a/src/components/Dropdown/Dropdown.stories.js
+++ b/src/components/Dropdown/Dropdown.stories.js
@@ -1,6 +1,8 @@
 import Dropdown from './Dropdown.vue';
 import mdx from './Dropdown.mdx';
 
+import { Eye } from '@/components/Icons';
+
 export default {
   title: 'Components/Dropdown',
   component: Dropdown,
@@ -277,5 +279,31 @@ WithOptGroups.args = {
       ]
     },
     'Brontosaurus'
+  ]
+};
+
+const IconTemplate = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: {  Dropdown, Eye },
+  data: () => ({ vModel }),
+  setup: () => ({ args }),
+  template: `
+    <dropdown v-bind="args" v-model="vModel">
+      <template v-slot:iconRight>
+        <eye class="w-5 h-5" />
+      </template>
+    </dropdown>
+  `
+});
+
+export const WithIcon = IconTemplate.bind({});
+WithIcon.args = {
+  id: 'galilean-moons',
+  label: 'Destination',
+  options: [
+    'Io',
+    'Europa',
+    'Ganymede',
+    'Callisto'
   ]
 };

--- a/src/components/Dropdown/Dropdown.vue
+++ b/src/components/Dropdown/Dropdown.vue
@@ -3,17 +3,13 @@
 <template>
   <div>
     <lob-label
+      v-if="label"
       :id="`${id}-label`"
       :label="label"
       :label-for="id"
       :required="required"
       :sr-only-label="srOnlyLabel"
-      v-if="label"
-    >
-      <template v-slot:iconRight>
-        <slot name="iconRight" />
-      </template>
-    </lob-label>
+    />
     <div
       :class="[
         'relative',

--- a/src/components/Dropdown/Dropdown.vue
+++ b/src/components/Dropdown/Dropdown.vue
@@ -8,7 +8,11 @@
       :label-for="id"
       :required="required"
       :sr-only-label="srOnlyLabel"
-    />
+    >
+      <template v-slot:iconRight>
+        <slot name="iconRight" />
+      </template>
+    </lob-label>
     <div
       :class="[
         'relative',

--- a/src/components/Dropdown/Dropdown.vue
+++ b/src/components/Dropdown/Dropdown.vue
@@ -161,7 +161,7 @@ export default {
     },
     label: {
       type: String,
-      default: ""
+      default: ''
     },
     srOnlyLabel: {
       type: Boolean,

--- a/src/components/Dropdown/Dropdown.vue
+++ b/src/components/Dropdown/Dropdown.vue
@@ -8,6 +8,7 @@
       :label-for="id"
       :required="required"
       :sr-only-label="srOnlyLabel"
+      v-if="label"
     >
       <template v-slot:iconRight>
         <slot name="iconRight" />
@@ -164,7 +165,7 @@ export default {
     },
     label: {
       type: String,
-      required: true
+      default: ""
     },
     srOnlyLabel: {
       type: Boolean,

--- a/src/components/LobLabel/LobLabel.stories.js
+++ b/src/components/LobLabel/LobLabel.stories.js
@@ -39,14 +39,14 @@ const WithTooltipTemplate = (args, { argTypes }) => ({
       </template>
     </lob-label>
     <input class="border rounded p-2 text-gray-500" />
-  `,
+  `
 });
 
 export const WithTooltip = WithTooltipTemplate.bind({});
 WithTooltip.args = {
-  label: "Name",
-  labelFor: "Name",
-  required: true,
+  label: 'Name',
+  labelFor: 'Name',
+  required: true
 };
 
 const WithInputTemplate = (args, { argTypes }) => ({

--- a/src/components/LobLabel/LobLabel.stories.js
+++ b/src/components/LobLabel/LobLabel.stories.js
@@ -1,7 +1,8 @@
 import LobLabel from './LobLabel.vue';
 import mdx from './LobLabel.mdx';
 
-import { Close } from '@/components/Icons';
+import { Info } from '@/components/Icons';
+import Tooltip from '@/components/Tooltip/Tooltip.vue';
 
 export default {
   title: 'Components/Label',
@@ -20,22 +21,29 @@ export default {
   }
 };
 
-const WithIconTemplate = (args, { argTypes }) => ({
+const WithTooltipTemplate = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
-  components: { LobLabel, Close },
+  components: { LobLabel, Info, Tooltip },
   setup: () => ({ args }),
   template: `
     <lob-label v-bind="args">
-      <template v-slot:iconRight>
-        <close class="w-5 h-5" />
+      <template v-slot:tooltip>
+        <Tooltip position="left">
+          <template #trigger>
+            <Info class="w-5 h-5" />
+          </template>
+          <template #content>
+            Cat
+          </template>
+        </Tooltip>
       </template>
     </lob-label>
     <input class="border rounded p-2 text-gray-500" />
   `,
 });
 
-export const WithIcon = WithIconTemplate.bind({});
-WithIcon.args = {
+export const WithTooltip = WithTooltipTemplate.bind({});
+WithTooltip.args = {
   label: "Name",
   labelFor: "Name",
   required: true,

--- a/src/components/LobLabel/LobLabel.stories.js
+++ b/src/components/LobLabel/LobLabel.stories.js
@@ -1,6 +1,8 @@
 import LobLabel from './LobLabel.vue';
 import mdx from './LobLabel.mdx';
 
+import { Close } from '@/components/Icons';
+
 export default {
   title: 'Components/Label',
   component: LobLabel,
@@ -16,6 +18,27 @@ export default {
       }
     }
   }
+};
+
+const WithIconTemplate = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { LobLabel, Close },
+  setup: () => ({ args }),
+  template: `
+    <lob-label v-bind="args">
+      <template v-slot:iconRight>
+        <close class="w-5 h-5" />
+      </template>
+    </lob-label>
+    <input class="border rounded p-2 text-gray-500" />
+  `
+});
+
+export const WithIcon = WithIconTemplate.bind({});
+WithIcon.args = {
+  label: 'Name',
+  labelFor: 'Name',
+  required: true
 };
 
 const WithInputTemplate = (args, { argTypes }) => ({

--- a/src/components/LobLabel/LobLabel.stories.js
+++ b/src/components/LobLabel/LobLabel.stories.js
@@ -31,14 +31,14 @@ const WithIconTemplate = (args, { argTypes }) => ({
       </template>
     </lob-label>
     <input class="border rounded p-2 text-gray-500" />
-  `
+  `,
 });
 
 export const WithIcon = WithIconTemplate.bind({});
 WithIcon.args = {
-  label: 'Name',
-  labelFor: 'Name',
-  required: true
+  label: "Name",
+  labelFor: "Name",
+  required: true,
 };
 
 const WithInputTemplate = (args, { argTypes }) => ({

--- a/src/components/LobLabel/LobLabel.vue
+++ b/src/components/LobLabel/LobLabel.vue
@@ -2,8 +2,9 @@
   <span>
     <label
       :for="labelFor"
-      :class="['block mb-2 text-sm text-gray-500', {'sr-only': srOnlyLabel}]"
+      :class="['flex items-center justify-between mb-2 text-sm text-gray-500', {'sr-only': srOnlyLabel}]"
     >
+    <span>
       {{ label }}
       <span
         v-if="required"
@@ -11,8 +12,14 @@
       >
         *
       </span>
+      </span>
+        <span
+          v-if="iconRight"
+          class="pt-1 pb-1"
+          >
+          <slot name="iconRight" />
+        </span>
     </label>
-    <slot />
   </span>
 </template>
 
@@ -25,6 +32,11 @@ export default defineComponent({
     labelFor: { type: String, required: true },
     required: { type: Boolean, default: false },
     srOnlyLabel: { type: Boolean, default: false }
+  },
+  computed: {
+    iconRight () {
+      return this.$slots.iconRight;
+    }
   }
 });
 </script>

--- a/src/components/LobLabel/LobLabel.vue
+++ b/src/components/LobLabel/LobLabel.vue
@@ -4,14 +4,22 @@
       :for="labelFor"
       :class="[
         'flex items-center justify-between mb-2 text-sm text-gray-500',
-        { 'sr-only': srOnlyLabel },
+        { 'sr-only': srOnlyLabel }
       ]"
     >
       <span>
         {{ label }}
-        <span v-if="required" class="text-sm text-turquoise-900"> * </span>
+        <span
+          v-if="required"
+          class="text-sm text-turquoise-900"
+        >
+          *
+        </span>
       </span>
-      <span v-if="tooltip" class="pt-1 pb-1">
+      <span
+        v-if="tooltip"
+        class="pt-1 pb-1"
+      >
         <slot name="tooltip" />
       </span>
     </label>

--- a/src/components/LobLabel/LobLabel.vue
+++ b/src/components/LobLabel/LobLabel.vue
@@ -11,8 +11,8 @@
         {{ label }}
         <span v-if="required" class="text-sm text-turquoise-900"> * </span>
       </span>
-      <span v-if="iconRight" class="pt-1 pb-1">
-        <slot name="iconRight" />
+      <span v-if="tooltip" class="pt-1 pb-1">
+        <slot name="tooltip" />
       </span>
     </label>
     <slot />
@@ -30,8 +30,8 @@ export default defineComponent({
     srOnlyLabel: { type: Boolean, default: false }
   },
   computed: {
-    iconRight () {
-      return this.$slots.iconRight;
+    tooltip () {
+      return this.$slots.tooltip;
     }
   }
 });

--- a/src/components/LobLabel/LobLabel.vue
+++ b/src/components/LobLabel/LobLabel.vue
@@ -2,23 +2,18 @@
   <span>
     <label
       :for="labelFor"
-      :class="['flex items-center justify-between mb-2 text-sm text-gray-500', {'sr-only': srOnlyLabel}]"
+      :class="[
+        'flex items-center justify-between mb-2 text-sm text-gray-500',
+        { 'sr-only': srOnlyLabel },
+      ]"
     >
-    <span>
-      {{ label }}
-      <span
-        v-if="required"
-        class="text-sm text-turquoise-900"
-      >
-        *
+      <span>
+        {{ label }}
+        <span v-if="required" class="text-sm text-turquoise-900"> * </span>
       </span>
+      <span v-if="iconRight" class="pt-1 pb-1">
+        <slot name="iconRight" />
       </span>
-        <span
-          v-if="iconRight"
-          class="pt-1 pb-1"
-          >
-          <slot name="iconRight" />
-        </span>
     </label>
     <slot />
   </span>

--- a/src/components/LobLabel/LobLabel.vue
+++ b/src/components/LobLabel/LobLabel.vue
@@ -20,6 +20,7 @@
           <slot name="iconRight" />
         </span>
     </label>
+    <slot />
   </span>
 </template>
 

--- a/src/components/TextInput/TextInput.stories.js
+++ b/src/components/TextInput/TextInput.stories.js
@@ -66,21 +66,21 @@ IconLeft.args = {
   placeholder: 'One'
 };
 
-const IconRightTemplate = (args, { argTypes }) => ({
+const LabelIconTemplate = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { TextInput, Close },
   setup: () => ({ args }),
   template: `
     <text-input v-bind="args">
-      <template v-slot:iconRight>
+      <template v-slot:labelIcon>
         <close class="w-5 h-5" />
       </template>
     </text-input>
   `
 });
 
-export const IconRight = IconRightTemplate.bind({});
-IconRight.args = {
+export const LabelIcon = LabelIconTemplate.bind({});
+LabelIcon.args = {
   id: 'one',
   label: 'One',
   placeholder: 'One'
@@ -95,7 +95,7 @@ const BothIconsTemplate = (args, { argTypes }) => ({
       <template v-slot:iconLeft>
         <search class="w-6 h-6" />
       </template>
-      <template v-slot:iconRight>
+      <template v-slot:labelIcon>
         <close class="w-5 h-5" />
       </template>
     </text-input>

--- a/src/components/TextInput/TextInput.stories.js
+++ b/src/components/TextInput/TextInput.stories.js
@@ -96,7 +96,7 @@ const BothIconsTemplate = (args, { argTypes }) => ({
         <search class="w-6 h-6" />
       </template>
       <template v-slot:iconRight>
-        <close class="w-6 h-6" />
+        <close class="w-5 h-5" />
       </template>
     </text-input>
   `

--- a/src/components/TextInput/TextInput.stories.js
+++ b/src/components/TextInput/TextInput.stories.js
@@ -78,17 +78,15 @@ const IconRightTemplate = (args, { argTypes }) => ({
         <close class="w-6 h-6" />
       </template>
     </text-input>
-  `,
+  `
 });
 
 export const IconRight = IconRightTemplate.bind({});
 IconRight.args = {
-  id: "one",
-  label: "One",
-  placeholder: "One",
+  id: 'one',
+  label: 'One',
+  placeholder: 'One'
 };
-
-
 
 const WithTooltipTemplate = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
@@ -111,7 +109,7 @@ const WithTooltipTemplate = (args, { argTypes }) => ({
       </template>
     </LobLabel>
     <text-input v-bind="args" />
-  `,
+  `
 });
 
 export const WithTooltip = WithTooltipTemplate.bind({});

--- a/src/components/TextInput/TextInput.stories.js
+++ b/src/components/TextInput/TextInput.stories.js
@@ -73,7 +73,7 @@ const IconRightTemplate = (args, { argTypes }) => ({
   template: `
     <text-input v-bind="args">
       <template v-slot:iconRight>
-        <close class="w-6 h-6" />
+        <close class="w-5 h-5" />
       </template>
     </text-input>
   `

--- a/src/components/TextInput/TextInput.stories.js
+++ b/src/components/TextInput/TextInput.stories.js
@@ -128,7 +128,7 @@ const BothIconsTemplate = (args, { argTypes }) => ({
         <search class="w-6 h-6" />
       </template>
       <template v-slot:iconRight>
-        <close class="w-5 h-5" />
+        <close class="w-6 h-6" />
       </template>
     </text-input>
   `

--- a/src/components/TextInput/TextInput.stories.js
+++ b/src/components/TextInput/TextInput.stories.js
@@ -1,7 +1,9 @@
 import TextInput from './TextInput.vue';
 import mdx from './TextInput.mdx';
 
-import { Close, Search } from '@/components/Icons';
+import LobLabel from '@/components/LobLabel/LobLabel.vue';
+import Tooltip from '@/components/Tooltip/Tooltip.vue';
+import { Close, Search, Info } from '@/components/Icons';
 
 export default {
   title: 'Components/Text Input',
@@ -66,24 +68,56 @@ IconLeft.args = {
   placeholder: 'One'
 };
 
-const LabelIconTemplate = (args, { argTypes }) => ({
+const IconRightTemplate = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { TextInput, Close },
   setup: () => ({ args }),
   template: `
     <text-input v-bind="args">
-      <template v-slot:labelIcon>
-        <close class="w-5 h-5" />
+      <template v-slot:iconRight>
+        <close class="w-6 h-6" />
       </template>
     </text-input>
-  `
+  `,
 });
 
-export const LabelIcon = LabelIconTemplate.bind({});
-LabelIcon.args = {
+export const IconRight = IconRightTemplate.bind({});
+IconRight.args = {
+  id: "one",
+  label: "One",
+  placeholder: "One",
+};
+
+
+
+const WithTooltipTemplate = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { TextInput, LobLabel, Info, Tooltip },
+  setup: () => ({ args }),
+  template: `
+    <LobLabel
+      label="Favorite Lunar Maria"
+      labelFor="one"
+    >
+      <template v-slot:tooltip>
+        <Tooltip>
+          <template #trigger>
+            <Info class="w-5 h-5" />
+          </template>
+          <template #content>
+            Moon
+          </template>      
+        </Tooltip>
+      </template>
+    </LobLabel>
+    <text-input v-bind="args" />
+  `,
+});
+
+export const WithTooltip = WithTooltipTemplate.bind({});
+WithTooltip.args = {
   id: 'one',
-  label: 'One',
-  placeholder: 'One'
+  placeholder: 'Mare Nectaris'
 };
 
 const BothIconsTemplate = (args, { argTypes }) => ({
@@ -95,7 +129,7 @@ const BothIconsTemplate = (args, { argTypes }) => ({
       <template v-slot:iconLeft>
         <search class="w-6 h-6" />
       </template>
-      <template v-slot:labelIcon>
+      <template v-slot:iconRight>
         <close class="w-5 h-5" />
       </template>
     </text-input>

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -7,7 +7,7 @@
       :sr-only-label="srOnlyLabel"
     >
       <template v-slot:iconRight>
-	      <slot name="iconRight" />
+	      <slot name="labelIcon" />
       </template>
     </lob-label>
     <div
@@ -159,8 +159,8 @@ export default {
     iconLeft () {
       return this.$slots.iconLeft;
     },
-    iconRight () {
-      return this.$slots.iconRight;
+    labelIcon () {
+      return this.$slots.labelIcon;
     },
     selectedOptions () {
       return this.$slots.selectedOptions;

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -7,7 +7,7 @@
       :sr-only-label="srOnlyLabel"
     >
       <template v-slot:iconRight>
-	<slot name="iconRight" />
+	      <slot name="iconRight" />
       </template>
     </lob-label>
     <div

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -5,7 +5,11 @@
       :label-for="id"
       :required="required"
       :sr-only-label="srOnlyLabel"
-    />
+    >
+      <template v-slot:iconRight>
+	<slot name="iconRight" />
+      </template>
+    </lob-label>
     <div
       data-testId="input-container"
       :class="[
@@ -46,12 +50,6 @@
         @input="onInput"
         @focus="onFocus"
       >
-      <div
-        v-if="iconRight"
-        :class="['pr-2 pt-3 pb-3 text-gray-500', {'!pr-1 !py-2': small}]"
-      >
-        <slot name="iconRight" />
-      </div>
       <button
         v-if="withCopyButton"
         :class="['rounded-tr-md rounded-br-md text-white bg-primary-500 border px-3',

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -7,7 +7,7 @@
       :sr-only-label="srOnlyLabel"
     >
       <template v-slot:iconRight>
-	      <slot name="labelIcon" />
+        <slot name="labelIcon" />
       </template>
     </lob-label>
     <div

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -5,11 +5,8 @@
       :label-for="id"
       :required="required"
       :sr-only-label="srOnlyLabel"
-    >
-      <template v-slot:iconRight>
-        <slot name="labelIcon" />
-      </template>
-    </lob-label>
+      v-if="label"
+    />
     <div
       data-testId="input-container"
       :class="[
@@ -50,6 +47,12 @@
         @input="onInput"
         @focus="onFocus"
       >
+      <div
+        v-if="iconRight"
+        :class="['pr-2 pt-3 pb-3 text-gray-500', {'!pr-1 !py-2': small}]"
+      >
+        <slot name="iconRight" />
+      </div>
       <button
         v-if="withCopyButton"
         :class="['rounded-tr-md rounded-br-md text-white bg-primary-500 border px-3',
@@ -105,7 +108,7 @@ export default {
     },
     label: {
       type: String,
-      required: true
+      default: ""
     },
     srOnlyLabel: {
       type: Boolean,
@@ -159,8 +162,8 @@ export default {
     iconLeft () {
       return this.$slots.iconLeft;
     },
-    labelIcon () {
-      return this.$slots.labelIcon;
+    iconRight () {
+      return this.$slots.iconRight;
     },
     selectedOptions () {
       return this.$slots.selectedOptions;

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -1,11 +1,11 @@
 <template>
   <div>
     <lob-label
+      v-if="label"
       :label="label"
       :label-for="id"
       :required="required"
       :sr-only-label="srOnlyLabel"
-      v-if="label"
     />
     <div
       data-testId="input-container"
@@ -108,7 +108,7 @@ export default {
     },
     label: {
       type: String,
-      default: ""
+      default: ''
     },
     srOnlyLabel: {
       type: Boolean,

--- a/src/components/Textarea/Textarea.stories.js
+++ b/src/components/Textarea/Textarea.stories.js
@@ -1,6 +1,8 @@
 import Textarea from './Textarea.vue';
 import mdx from './Textarea.mdx';
 
+import { Close } from '@/components/Icons';
+
 export default {
   title: 'Components/Textarea',
   component: Textarea,
@@ -32,3 +34,22 @@ Primary.args = {
   placeholder: 'Enter a fun fact'
 };
 
+const LabelIconTemplate = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { Textarea, Close },
+  setup: () => ({ args }),
+  template: `
+    <Textarea v-bind="args">
+        <template v-slot:labelIcon>
+          <close class="w-5 h-5" />
+        </template>
+    </Textarea>
+  `,
+});
+
+export const LabelIcon = LabelIconTemplate.bind({});
+LabelIcon.args = {
+  id: "textarea",
+  label: "Cat nicknames",
+  placeholder: "Please list at least 8 of your cat's most interesting nicknames",
+ };

--- a/src/components/Textarea/Textarea.stories.js
+++ b/src/components/Textarea/Textarea.stories.js
@@ -1,7 +1,9 @@
 import Textarea from './Textarea.vue';
 import mdx from './Textarea.mdx';
 
-import { Close } from '@/components/Icons';
+import { Info } from '@/components/Icons';
+import LobLabel from '@/components/LobLabel/LobLabel.vue'
+import Tooltip from '@/components/Tooltip/Tooltip.vue'
 
 export default {
   title: 'Components/Textarea',
@@ -34,22 +36,32 @@ Primary.args = {
   placeholder: 'Enter a fun fact'
 };
 
-const LabelIconTemplate = (args, { argTypes }) => ({
+const WithTooltipTemplate = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
-  components: { Textarea, Close },
+  components: { Textarea, Info, LobLabel, Tooltip },
   setup: () => ({ args }),
   template: `
-    <Textarea v-bind="args">
-        <template v-slot:labelIcon>
-          <close class="w-5 h-5" />
-        </template>
-    </Textarea>
+    <LobLabel
+      label="Cat nicknames"
+      labelFor="textarea"
+    >
+      <template v-slot:tooltip>
+        <Tooltip>
+          <template #trigger>
+            <Info class="w-5 h-5" />
+          </template>
+          <template #content>
+            Cat
+          </template>      
+        </Tooltip>
+      </template>
+    </LobLabel>
+    <Textarea v-bind="args" />
   `,
 });
 
-export const LabelIcon = LabelIconTemplate.bind({});
-LabelIcon.args = {
+export const WithTooltip = WithTooltipTemplate.bind({});
+WithTooltip.args = {
   id: "textarea",
-  label: "Cat nicknames",
   placeholder: "Please list at least 8 of your cat's most interesting nicknames",
  };

--- a/src/components/Textarea/Textarea.stories.js
+++ b/src/components/Textarea/Textarea.stories.js
@@ -2,8 +2,8 @@ import Textarea from './Textarea.vue';
 import mdx from './Textarea.mdx';
 
 import { Info } from '@/components/Icons';
-import LobLabel from '@/components/LobLabel/LobLabel.vue'
-import Tooltip from '@/components/Tooltip/Tooltip.vue'
+import LobLabel from '@/components/LobLabel/LobLabel.vue';
+import Tooltip from '@/components/Tooltip/Tooltip.vue';
 
 export default {
   title: 'Components/Textarea',
@@ -57,11 +57,11 @@ const WithTooltipTemplate = (args, { argTypes }) => ({
       </template>
     </LobLabel>
     <Textarea v-bind="args" />
-  `,
+  `
 });
 
 export const WithTooltip = WithTooltipTemplate.bind({});
 WithTooltip.args = {
-  id: "textarea",
-  placeholder: "Please list at least 8 of your cat's most interesting nicknames",
- };
+  id: 'textarea',
+  placeholder: 'Please list at least 8 of your cat\'s most interesting nicknames'
+};

--- a/src/components/Textarea/Textarea.vue
+++ b/src/components/Textarea/Textarea.vue
@@ -4,24 +4,24 @@
     :label-for="id"
     :required="required"
     :sr-only-label="srOnlyLabel"
-  >
-    <textarea
-      :id="id"
-      :value="modelValue"
-      :name="name"
-      :required="required"
-      :disabled="disabled"
-      :readonly="readonly"
-      :placeholder="placeholder"
-      :class="[
-        'bg-white text-gray-500 placeholder-gray-100 p-4 w-full h-full resize-none rounded border border-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-100 focus:border-transparent',
-        {'border-error': error},
-        {'!bg-white-300 cursor-not-allowed': disabled || readonly},
-        {'hover:shadow': !disabled && !readonly}
-      ]"
-      @input="onInput"
-    />
-  </lob-label>
+    v-if="label"
+  />
+  <textarea
+    :id="id"
+    :value="modelValue"
+    :name="name"
+    :required="required"
+    :disabled="disabled"
+    :readonly="readonly"
+    :placeholder="placeholder"
+    :class="[
+      'bg-white text-gray-500 placeholder-gray-100 p-4 resize-none rounded border border-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-100 focus:border-transparent',
+      { 'border-error': error },
+      { '!bg-white-300 cursor-not-allowed': disabled || readonly },
+      { 'hover:shadow': !disabled && !readonly },
+    ]"
+    @input="onInput"
+  />
 </template>
 
 <script>

--- a/src/components/Textarea/Textarea.vue
+++ b/src/components/Textarea/Textarea.vue
@@ -1,10 +1,10 @@
 <template>
   <lob-label
+    v-if="label"
     :label="label"
     :label-for="id"
     :required="required"
     :sr-only-label="srOnlyLabel"
-    v-if="label"
   />
   <textarea
     :id="id"
@@ -18,7 +18,7 @@
       'bg-white text-gray-500 placeholder-gray-100 p-4 resize-none rounded border border-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-100 focus:border-transparent',
       { 'border-error': error },
       { '!bg-white-300 cursor-not-allowed': disabled || readonly },
-      { 'hover:shadow': !disabled && !readonly },
+      { 'hover:shadow': !disabled && !readonly }
     ]"
     @input="onInput"
   />


### PR DESCRIPTION
## JIRA

[DANG-445
](https://lobsters.atlassian.net/browse/DANG-445)

## Description

The current implementation of tooltips involves an icon placed inside the input, which looks really cool and clean! But it's not great for accessibility and it doesn't work with the chevron for dropdowns. So for consistency and accessibility reasons, this PR moves the tooltip into LobLabel and updates three components that use tooltips and adds stories demonstrating their use:
* TextInput
* Textarea
* Dropdown

![image](https://user-images.githubusercontent.com/200723/135503727-24865a5b-7b08-4128-a2cb-6bac78164b83.png)

## Areas of Concern
- We probably want to give some thought to how this works with keyboard only navigation.

## Questions
- Are there any other components we should update prior to release?

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
