### PR TITLE
add Number to modelValue prop types, as this input is also used as ty…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.131",
+  "version": "0.0.132",
   "engines": {
     "node": "14.16.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.132",
+  "version": "0.0.133",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -77,7 +77,7 @@ export default {
   },
   props: {
     modelValue: {
-      type: String,
+      type: [String, Number],
       default: null
     },
     id: {


### PR DESCRIPTION
…pe="number"

## JIRA

[* A link to the JIRA ticket](https://lobsters.atlassian.net/jira/software/c/projects/DANG/boards/106?modal=detail&selectedIssue=DANG-508)

## Description

The TextInput correctly accepts different types of input type with type prop (type="x" etc) but
when using the TextInput with type="number" it throws warnings that it "expected a String but got a Number instead"
(This was not caught so far because we haven't used type="number" much)

This adds Number as an accepted prop type for modelValue of TextInput.

No visual changes.