### PR TITLE
keep API uppercase on the Breadcrumb

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.142",
+  "version": "0.0.143",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/Breadcrumb/Breadcrumb.vue
+++ b/src/components/Breadcrumb/Breadcrumb.vue
@@ -72,9 +72,9 @@ export default {
       let sanitizedStr = str.toLowerCase();
 
       let splitStr = sanitizedStr.split(' ');
-      splitStr = splitStr.map((word) => word.replace(/^[a-z]/i, (letter) => {
+      splitStr = splitStr.map((word) => (word === 'api' ? word.replace(word, 'API') : word.replace(/^[a-z]/i, (letter) => {
         return letter.toUpperCase();
-      }));
+      })));
 
       sanitizedStr = splitStr.join(' ');
       return sanitizedStr.trim();


### PR DESCRIPTION
[JIRA ticket](https://lobsters.atlassian.net/browse/DANG-580)

Adding a condition in the sanitize-string function to replace 'api' with 'API' (instead of capitalizing the 1st letter only).

Could not figure out how to add a second story on this. If we want to show this in a story plz help.

Otherwise _let's hope it works_ and here it is faked:
<img width="193" alt="Screen Shot 2021-10-20 at 9 24 46 AM" src="https://user-images.githubusercontent.com/50080618/138133185-cd73c630-23f4-4393-a3fa-c92a88d1d53e.png">

