### PR TITLE
add '?' in SubnavigationItem computed value, fixes undefined error showing in dashboard 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.144",
+  "version": "0.0.145",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/Subnavigation/SubnavigationItem.vue
+++ b/src/components/Subnavigation/SubnavigationItem.vue
@@ -34,7 +34,7 @@ export default {
   },
   computed: {
     active () {
-      return this.matchQueryString ? this.$route.fullPath === this.to : this.$route.fullPath.includes(this.to);
+      return this.matchQueryString ? this.$route.fullPath === this.to : this.$route?.fullPath?.includes(this.to);
     }
   }
 };


### PR DESCRIPTION
not on jira

we're getting some failing tests now on dashboard-vue when trying to update the package

TypeError: Cannot read property 'includes' of undefined

This might be it, but am unable to test without updating from this side - the assumption after the failed tests start at version 143 where this line was added.

You can see the error logs on this isolated branch [here](https://app.circleci.com/pipelines/github/lob/dashboard-vue?branch=package-ui-update)

The plan is to merge this and pull it onto the test branch (package-ui-update) in vue to see what happens.

Thoughts please?