### PR TITLE
Dang 544 Modal close behavior 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.142",
+  "version": "0.0.143",
   "engines": {
     "node": "14.16.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.143",
+  "version": "0.0.144",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -3,7 +3,7 @@
     <div
       v-show="visible"
       :class="['fixed inset-0 flex items-center justify-center bg-black bg-opacity-60 z-30']"
-      @click="closeModal"
+      @mousedown="closeModal"
     >
       <div
         class="bg-white flex flex-col overflow-auto shadow rounded-lg p-5 max-h-5/6"
@@ -11,7 +11,7 @@
         aria-labelledby="modalTitle"
         aria-describedby="modalDescription"
         :style="{'width': width}"
-        @click.stop
+        @mousedown.stop
       >
         <header
           v-if="hasHeader"

--- a/src/components/Subnavigation/SubnavigationItem.vue
+++ b/src/components/Subnavigation/SubnavigationItem.vue
@@ -4,8 +4,7 @@
   >
     <LobLink
       :to="to"
-      class="inline-block relative pb-4 no-underline text-black font-light"
-      :exact-active-class="exactActiveClass"
+      :class="['inline-block relative pb-4 no-underline text-black font-light', { 'lob-active-border font-normal': active }]"
       data-testid="subnav-item"
     >
       {{ title }}
@@ -34,14 +33,8 @@ export default {
     }
   },
   computed: {
-    exactActiveClass () {
-      const activeClass = 'lob-active-border font-normal';
-      const matchWithQueryString = this.$route.fullPath === this.to;
-      if (this.matchQueryString) {
-        return matchWithQueryString ? activeClass : '';
-      } else {
-        return activeClass;
-      }
+    active () {
+      return this.matchQueryString ? this.$route.fullPath === this.to : this.$route.fullPath.includes(this.to);
     }
   }
 };


### PR DESCRIPTION
## JIRA

[https://lobsters.atlassian.net/browse/DANG-544](https://lobsters.atlassian.net/browse/DANG-544)

## Description

###Original ticket description:

Multiple times when creating new addresses the modal closed and I lost all my data and had to start again.

nav to postcard -> create new address

click anywhere within modal, move mouse outside of modal area, then release click

modal closes on mouseup, and you lose all your progress

expected:

modal only closes when you click outside of the modal.

This happens frequently since when selecting a field with the mouse if you don't release click while within the modal, it closes.

###My comments:

I noticed this is the behavior on all modals.  If you click inside the modal, drag the mouse, and release click outside of the modal, the modal will close.  Better behavior would be for the modal to close only when you initiate a click outside of it.  I changed the click event binding to a mousedown instead of click.
