### PR TITLE
Top Nav focus rings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.147",
+  "version": "0.0.148",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/MegaMenu/MegaMenu.vue
+++ b/src/components/MegaMenu/MegaMenu.vue
@@ -13,7 +13,7 @@
       :aria-controls="dropdownListId"
       aria-haspopup="menu"
     >
-      <div 
+      <div
         tabindex="0"
         class="focus:outline-none focus:opacity-100 focus:ring-2 focus:ring-primary-100 focus:border-transparent flex-nowrap flex mt-0 flex-row justify-between xl:justify-start items-center px-2 py-1 xl:px-0 xl:py-0"
       >

--- a/src/components/MegaMenu/MegaMenu.vue
+++ b/src/components/MegaMenu/MegaMenu.vue
@@ -85,6 +85,9 @@ export default {
     }
   },
   methods: {
+    onBlur () {
+      this.showNav = false;
+    },
     onEscape () {
       this.showNav = false;
       this.showMobileNav = false;

--- a/src/components/MegaMenu/MegaMenu.vue
+++ b/src/components/MegaMenu/MegaMenu.vue
@@ -85,6 +85,7 @@ export default {
   },
   methods: {
     onClick ($event) {
+      this.showNav = !this.showNav;
       this.showMobileNav = !this.showMobileNav;
       this.$emit('click', $event);
     }

--- a/src/components/MegaMenu/MegaMenu.vue
+++ b/src/components/MegaMenu/MegaMenu.vue
@@ -4,6 +4,7 @@
     data-testId="menu-container"
     @mouseenter="showNav = true"
     @mouseleave="showNav = false"
+    @keyup.enter="onClick"
     @click="onClick"
   >
     <div
@@ -12,7 +13,10 @@
       :aria-controls="dropdownListId"
       aria-haspopup="menu"
     >
-      <div class="flex-nowrap flex mt-0 flex-row justify-between xl:justify-start items-center px-2 py-1 xl:px-0 xl:py-0">
+      <div 
+        tabindex="0"
+        class="focus:outline-none focus:opacity-100 focus:ring-2 focus:ring-primary-100 focus:border-transparent flex-nowrap flex mt-0 flex-row justify-between xl:justify-start items-center px-2 py-1 xl:px-0 xl:py-0"
+      >
         {{ title }}
         <img
           :src="`${$getConst('lobAssetsUrl')}/dashboard/navbar/caret-down.svg`"

--- a/src/components/MegaMenu/MegaMenu.vue
+++ b/src/components/MegaMenu/MegaMenu.vue
@@ -16,6 +16,7 @@
       <div
         tabindex="0"
         class="focus:outline-none focus:opacity-100 focus:ring-2 focus:ring-primary-100 focus:border-transparent flex-nowrap flex mt-0 flex-row justify-between xl:justify-start items-center px-2 py-1 xl:px-0 xl:py-0"
+        @keyup.esc="onEscape"
       >
         {{ title }}
         <img
@@ -84,6 +85,10 @@ export default {
     }
   },
   methods: {
+    onEscape () {
+      this.showNav = false;
+      this.showMobileNav = false;
+    },
     onClick ($event) {
       this.showNav = !this.showNav;
       this.showMobileNav = !this.showMobileNav;

--- a/src/components/MegaMenu/MegaMenu.vue
+++ b/src/components/MegaMenu/MegaMenu.vue
@@ -6,6 +6,8 @@
     @mouseleave="showNav = false"
     @keyup.enter="onClick"
     @click="onClick"
+    @keydown="onKeydown"
+    @keyup.esc="onEscape"
   >
     <div
       :id="dropdownToggleId"
@@ -14,9 +16,9 @@
       aria-haspopup="menu"
     >
       <div
+        ref="titleItem"
         tabindex="0"
         class="focus:outline-none focus:opacity-100 focus:ring-2 focus:ring-primary-100 focus:border-transparent flex-nowrap flex mt-0 flex-row justify-between xl:justify-start items-center px-2 py-1 xl:px-0 xl:py-0"
-        @keyup.esc="onEscape"
       >
         {{ title }}
         <img
@@ -86,11 +88,19 @@ export default {
     }
   },
   methods: {
+    onKeydown ($event) {
+      const lastMenuItem = this.$refs.dropdownMenu.lastElementChild.firstChild;
+
+      if ($event.key === 'Tab' && !$event.shiftKey && $event.target === lastMenuItem) {
+        this.onBlur();
+      }
+    },
     onBlur () {
       this.showNav = false;
       this.showMobileNav = false;
     },
     onEscape () {
+      this.$refs.titleItem.focus();
       this.showNav = false;
       this.showMobileNav = false;
     },

--- a/src/components/MegaMenu/MegaMenu.vue
+++ b/src/components/MegaMenu/MegaMenu.vue
@@ -87,6 +87,7 @@ export default {
   methods: {
     onBlur () {
       this.showNav = false;
+      this.showMobileNav = false;
     },
     onEscape () {
       this.showNav = false;

--- a/src/components/MegaMenu/MegaMenu.vue
+++ b/src/components/MegaMenu/MegaMenu.vue
@@ -33,6 +33,7 @@
       :class="['hidden height-0 min-w-full xl:rounded-lg xl:bg-white xl:absolute', {'!block xl:hidden': showMobileNav}, {'xl:top-9 xl:!block': showNav}, {'xl:!hidden': !showNav}, {'xl:right-0': right}]"
     >
       <div
+        ref="dropdownMenu"
         :class="['height-0 pt-6 pb-4 px-4 h-auto w-full mt-1 border-gray-100 opacity-100',
                  {'!w-full xl:!mt-0': showMobileNav},
                  {'boxShadowGray xl:border-none xl:rounded-lg xl:bg-white': showNav}]"

--- a/src/components/MegaMenu/MegaMenuItem.vue
+++ b/src/components/MegaMenu/MegaMenuItem.vue
@@ -4,6 +4,7 @@
       {'pb-2': small},
       {'pb-4': !small}
     ]"
+    @keyup.esc="onEscape"
   >
     <LobLink
       :to="to"
@@ -59,6 +60,11 @@ export default {
     small: {
       type: Boolean,
       default: false
+    }
+  },
+  methods: {
+    onEscape () {
+      this.$parent.onEscape();
     }
   }
 };

--- a/src/components/MegaMenu/MegaMenuItem.vue
+++ b/src/components/MegaMenu/MegaMenuItem.vue
@@ -4,12 +4,10 @@
       {'pb-2': small},
       {'pb-4': !small}
     ]"
-    @keyup.esc="onEscape"
   >
     <LobLink
       :to="to"
       class="flex pt-1 flex-nowrap items-center hover:text-primary-500 w-64 no-underline"
-      @blur="onBlur"
     >
       <img
         :src="imageSource"
@@ -61,18 +59,6 @@ export default {
     small: {
       type: Boolean,
       default: false
-    }
-  },
-  methods: {
-    onBlur ($event) {
-      const lastChild = this.$parent.$refs.dropdownMenu.lastElementChild.firstChild;
-
-      if ($event.target === lastChild) {
-        this.$parent.onBlur();
-      }
-    },
-    onEscape () {
-      this.$parent.onEscape();
     }
   }
 };

--- a/src/components/MegaMenu/MegaMenuItem.vue
+++ b/src/components/MegaMenu/MegaMenuItem.vue
@@ -9,6 +9,7 @@
     <LobLink
       :to="to"
       class="flex pt-1 flex-nowrap items-center hover:text-primary-500 w-64 no-underline"
+      @blur="onBlur"
     >
       <img
         :src="imageSource"
@@ -63,6 +64,13 @@ export default {
     }
   },
   methods: {
+    onBlur ($event) {
+      const lastChild = $event.target.parentElement.parentElement.lastElementChild.firstChild;
+
+      if ($event.target === lastChild) {
+        this.$parent.onBlur();
+      }
+    },
     onEscape () {
       this.$parent.onEscape();
     }

--- a/src/components/MegaMenu/MegaMenuItem.vue
+++ b/src/components/MegaMenu/MegaMenuItem.vue
@@ -65,7 +65,7 @@ export default {
   },
   methods: {
     onBlur ($event) {
-      const lastChild = $event.target.parentElement.parentElement.lastElementChild.firstChild;
+      const lastChild = this.$parent.$refs.dropdownMenu.lastElementChild.firstChild;
 
       if ($event.target === lastChild) {
         this.$parent.onBlur();

--- a/src/components/MegaMenu/MegaMenuItem.vue
+++ b/src/components/MegaMenu/MegaMenuItem.vue
@@ -4,6 +4,7 @@
       {'pb-2': small},
       {'pb-4': !small}
     ]"
+    @keydown.enter="onEnter"
   >
     <LobLink
       :to="to"
@@ -59,6 +60,11 @@ export default {
     small: {
       type: Boolean,
       default: false
+    }
+  },
+  methods: {
+    onEnter () {
+      this.$parent.$refs.titleItem.focus();
     }
   }
 };

--- a/src/components/MegaMenu/MegaMenuItem.vue
+++ b/src/components/MegaMenu/MegaMenuItem.vue
@@ -7,7 +7,7 @@
   >
     <LobLink
       :to="to"
-      class="flex pt-1 flex-nowrap items-center hover:text-primary-500 w-64 no-underline"
+      class="focus:outline-none focus:opacity-100 focus:ring-2 focus:ring-primary-100 focus:border-transparent flex pt-1 flex-nowrap items-center hover:text-primary-500 w-64 no-underline"
     >
       <img
         :src="imageSource"


### PR DESCRIPTION
## JIRA

[https://lobsters.atlassian.net/browse/DANG-307](https://lobsters.atlassian.net/browse/DANG-307)

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description
You can now navigate the navbar with tab, enter to open submenu, esc to close submenu, and shift+tab to navigate backwards.

### Before: you could not tab into menu option or open menu with enter

<img width="466" alt="Screen Shot 2021-11-05 at 1 08 04 PM" src="https://user-images.githubusercontent.com/78509611/140550664-673713f1-0595-4cae-9ac7-737900cfc4ca.png">

### After menu item has focus ring and can be opened with Enter:

<img width="490" alt="Screen Shot 2021-11-05 at 1 10 00 PM" src="https://user-images.githubusercontent.com/78509611/140550817-40ded0ee-ebe9-41b7-a6e6-3ea0ec596d1a.png">

<!--
## Screenshots
- before and after screenshots for features with visual changes
-->

<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
