### PR TITLE
made improvements to topnav keyboard navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.148",
+  "version": "0.0.149",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/MegaMenu/MegaMenu.vue
+++ b/src/components/MegaMenu/MegaMenu.vue
@@ -89,9 +89,15 @@ export default {
   },
   methods: {
     onKeydown ($event) {
-      const lastMenuItem = this.$refs.dropdownMenu.lastElementChild.firstChild;
+      const anchorTags = this.$refs.dropdownMenu.getElementsByTagName('a');
+      const firstAnchorTag = anchorTags[0];
+      const lastAnchorTag = anchorTags[anchorTags.length - 1];
 
-      if ($event.key === 'Tab' && !$event.shiftKey && $event.target === lastMenuItem) {
+      if ($event.key === 'Tab' && $event.shiftKey && $event.target === firstAnchorTag) {
+        this.onBlur();
+      }
+
+      if ($event.key === 'Tab' && !$event.shiftKey && $event.target === lastAnchorTag) {
         this.onBlur();
       }
     },


### PR DESCRIPTION
## JIRA

[https://lobsters.atlassian.net/browse/DANG-307](https://lobsters.atlassian.net/browse/DANG-307)

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

This is another PR pertaining to DANG-307 Nav Focus Rings and Keyboard navigability. Previous PR has been merged already, but did not account for Megamenus containing two submenus. This fix allows submenus to close after tabbing out of last anchor tag in the submenu, it also closes the submenu if you shift + tab backwards out of the submenu. Hitting enter will navigate you to the selected link.

<!--
## Screenshots
- before and after screenshots for features with visual changes
-->

<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
