### PR TITLE
DANG-739 make RadioButton label look the same as the Checkbox label, as per lob figma design

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.152",
+  "version": "0.0.153",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/RadioButton/RadioButton.vue
+++ b/src/components/RadioButton/RadioButton.vue
@@ -26,7 +26,7 @@
     <label
       :for="id"
       :class="[
-        'text-sm font-light relative flex ml-1.5',
+        'relative flex ml-1.5',
         { 'cursor-not-allowed': disabled || readonly }
       ]"
     >
@@ -115,7 +115,7 @@ input {
 
     &::before {
       content: "";
-      top: 3px;
+      top: 5px;
       left: -19px;
 
       @apply absolute;


### PR DESCRIPTION
## JIRA

[JIRA ticket](https://lobsters.atlassian.net/browse/DANG-739)

related PR: [https://github.com/lob/dashboard-vue/pull/341](https://github.com/lob/dashboard-vue/pull/341)

## Description

According to figma lob design the Checkbox and the RadioButton labels should look the same, normal size font and semibold. 
[https://www.figma.com/file/PFyulPE8zYVuRxRAhnhd7T/LOB-Design-System-(Updated)?node-id=31%3A453](https://www.figma.com/file/PFyulPE8zYVuRxRAhnhd7T/LOB-Design-System-(Updated)?node-id=31%3A453)
<img width="670" alt="Screen Shot 2021-11-22 at 8 43 00 AM" src="https://user-images.githubusercontent.com/50080618/143037985-54f1b0c8-2c10-4b26-9177-304ac4c54516.png">


Before:
<img width="319" alt="Screen Shot 2021-11-23 at 7 57 26 AM" src="https://user-images.githubusercontent.com/50080618/143037888-a2e5077f-de30-4bb4-9180-977ccf948920.png">

After:
<img width="319" alt="Screen Shot 2021-11-23 at 7 56 50 AM" src="https://user-images.githubusercontent.com/50080618/143037840-2840ae8a-9d76-46bd-97af-3a46098d362d.png">

Checkbox:
<img width="319" alt="Screen Shot 2021-11-23 at 7 56 57 AM" src="https://user-images.githubusercontent.com/50080618/143037857-3c2d848d-30dd-4ec1-886b-d4eca8afb104.png">


