### PR TITLE
Dang 432/adds 'Copied' Tooltip to TextInput to show when copying with the Copy Button (withCopyButton prop)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.158",
+  "version": "0.0.159",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/TextInput/TextInput.stories.js
+++ b/src/components/TextInput/TextInput.stories.js
@@ -141,3 +141,19 @@ BothIcons.args = {
   label: 'One',
   placeholder: 'One'
 };
+
+const WithCopyButtonTemplate = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { TextInput },
+  setup: () => ({ args }),
+  template: '<text-input v-bind="args"/>'
+});
+
+export const WithCopyButton = WithCopyButtonTemplate.bind({});
+WithCopyButton.args = {
+  id: 'copy-this',
+  label: 'Copy this',
+  modelValue: 'Something to Copy',
+  readonly: true,
+  withCopyButton: true
+};

--- a/src/components/TextInput/TextInput.stories.js
+++ b/src/components/TextInput/TextInput.stories.js
@@ -153,7 +153,7 @@ export const WithCopyButton = WithCopyButtonTemplate.bind({});
 WithCopyButton.args = {
   id: 'copy-this',
   label: 'Copy this',
-  modelValue: 'Something to Copy',
+  modelValue: 'Direct Mail and Address Verification',
   readonly: true,
   withCopyButton: true
 };

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -9,7 +9,7 @@
       :tooltip-content="tooltipContent"
     />
     <div
-      ref="copiedTip"
+      data-testId="copiedTip"
       :class="[
         'z-10 absolute w-20 p-2 text-xs rounded-md bg-gray-700 text-white',
         'transform translate-x-20 -translate-y-9 duration-300',

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -54,7 +54,7 @@
           `rounded pl-2 pt-3 pb-3 leading-5 w-full text-gray-500 placeholder-gray-100 outline-none ${inputClass}`,
           {'!pl-4': !iconLeft},
           {'!pl-3 !pr-3 !py-2': small},
-          {'border border-r-0 border-gray-100 rounded-tr-none rounded-br-none': withCopyButton},
+          {'border border-r-0 border-gray-100 rounded-tr-none rounded-br-none truncate': withCopyButton},
           {'bg-white-300 cursor-not-allowed': disabled || readonly},
           {'border-error': error}
         ]"

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="relative">
     <lob-label
       v-if="label"
       :label="label"
@@ -8,6 +8,23 @@
       :sr-only-label="srOnlyLabel"
       :tooltip-content="tooltipContent"
     />
+    <div
+      ref="copiedTip"
+      :class="[
+        'z-10 absolute w-20 p-2 text-xs rounded-md bg-gray-700 text-white',
+        'transform translate-x-20 -translate-y-9 duration-300',
+        {'opacity-100 -translate-y-11': copied },
+        {'opacity-0': !copied }
+      ]"
+    >
+      <div class="flex">
+        <Check class="h-4 w-4" />
+        <div class="ml-1.5">
+          Copied
+        </div>
+      </div>
+      <div class="absolute bg-transparent w-0 h-0 m-auto border-l-8 border-r-8 border-t-8 border-l-transparent border-r-transparent border-t-gray-700 -bottom-2 left-0 right-0" />
+    </div>
     <div
       data-testId="input-container"
       :class="[
@@ -71,11 +88,13 @@
 
 <script>
 import LobLabel from '../LobLabel/LobLabel.vue';
+import Check  from '../Icons/Check.vue';
 
 export default {
   name: 'TextInput',
   components: {
-    LobLabel
+    LobLabel,
+    Check
   },
   props: {
     tooltipContent: {
@@ -161,6 +180,11 @@ export default {
     }
   },
   emits: ['update:modelValue', 'input', 'change', 'focus', 'copy'],
+  data () {
+    return {
+      copied: false
+    };
+  },
   computed: {
     small () {
       return this.size === 'small';
@@ -180,6 +204,10 @@ export default {
       this.$refs.input.select();
       document.execCommand('copy');
       this.$emit('copy');
+      this.copied = true;
+      setTimeout(() => {
+        this.copied = false;
+      }, 1500);
     },
     onInput ($event) {
       this.$emit('update:modelValue', $event.target.value);

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative">
+  <div :class="{ 'relative': withCopyButton }">
     <lob-label
       v-if="label"
       :label="label"
@@ -9,21 +9,33 @@
       :tooltip-content="tooltipContent"
     />
     <div
-      data-testId="copiedTip"
-      :class="[
-        'z-10 absolute w-20 p-2 text-xs rounded-md bg-gray-700 text-white',
-        'transform translate-x-20 -translate-y-9 duration-300',
-        {'opacity-100 -translate-y-11': copied },
-        {'opacity-0': !copied }
-      ]"
+      v-if="withCopyButton"
+      aria-role="alert"
+      aria-live="polite"
+      class="absolute -top-4 ml-20"
     >
-      <div class="flex">
-        <Check class="h-4 w-4" />
-        <div class="ml-1.5">
-          Copied
+      <transition
+        enter-active-class="duration-1000 ease-out"
+        enter-from-class="opacity-0 transform translate-y-2"
+        enter-to-class="opacity-100 transform translate-y-0"
+        leave-active-class="duration-500 ease-out"
+        leave-from-class="opacity-100 transform translate-y-0"
+        leave-to-class="opacity-0 transform translate-y-2"
+      >
+        <div
+          v-if="showCopied"
+          data-testId="copiedTip"
+          class="z-10 w-20 p-2 text-xs rounded-md bg-gray-700 text-white"
+        >
+          <div class="flex">
+            <Check class="h-4 w-4" />
+            <div class="ml-1.5">
+              Copied
+            </div>
+          </div>
+          <div class="absolute bg-transparent w-0 h-0 m-auto border-l-8 border-r-8 border-t-8 border-l-transparent border-r-transparent border-t-gray-700 -bottom-2 left-0 right-0" />
         </div>
-      </div>
-      <div class="absolute bg-transparent w-0 h-0 m-auto border-l-8 border-r-8 border-t-8 border-l-transparent border-r-transparent border-t-gray-700 -bottom-2 left-0 right-0" />
+      </transition>
     </div>
     <div
       data-testId="input-container"
@@ -182,7 +194,7 @@ export default {
   emits: ['update:modelValue', 'input', 'change', 'focus', 'copy'],
   data () {
     return {
-      copied: false
+      showCopied: false
     };
   },
   computed: {
@@ -201,12 +213,13 @@ export default {
   },
   methods: {
     copyToClipboard () {
+      this.showCopied = true;
       this.$refs.input.select();
       document.execCommand('copy');
       this.$emit('copy');
       this.copied = true;
       setTimeout(() => {
-        this.copied = false;
+        this.showCopied = false;
       }, 1500);
     },
     onInput ($event) {

--- a/src/components/TextInput/__tests__/TextInput.spec.js
+++ b/src/components/TextInput/__tests__/TextInput.spec.js
@@ -91,24 +91,6 @@ describe('Text input', () => {
     expect(emittedEvent.input[0]).toEqual([updatedValue]);
   });
 
-  it('renders when withCopyButton prop is true', async () => {
-    const props = {
-      ...initialProps,
-      withCopyButton: true
-    };
-    const { getByRole, emitted } = render(TextInput, {
-      props
-    });
-
-    const button = getByRole('button', { name: /copy/i });
-    expect(button).toBeInTheDocument();
-
-    document.execCommand = jest.fn();
-    await fireEvent.click(button);
-    const emittedEvent = emitted();
-    expect(emittedEvent).toHaveProperty('copy');
-  });
-
   it('selects on click when selectOnClick prop is true', async () => {
     const props = {
       ...initialProps,
@@ -136,6 +118,46 @@ describe('Text input', () => {
 
     const slot = getByText(new RegExp(slotContent));
     expect(slot).toBeInTheDocument();
+  });
+
+  describe('with Copy Button', () => {
+
+    let component;
+    beforeEach(async () => {
+      const props = {
+        ...initialProps,
+        withCopyButton: true
+      };
+      component = render(TextInput, {
+        props
+      });
+    });
+
+    it('renders the Copy button that emits \'copy\' event onClick', async () => {
+      const { getByRole, emitted } = component;
+
+      const button = getByRole('button', { name: /copy/i });
+      expect(button).toBeInTheDocument();
+
+      document.execCommand = jest.fn();
+      await fireEvent.click(button);
+      const emittedEvent = emitted();
+      expect(emittedEvent).toHaveProperty('copy');
+    });
+
+    it('shows the \'Copied\' tooltip when copied', async () => {
+      const { getByRole, queryByTestId, findByTestId } = component;
+
+      const notVisibleTip = queryByTestId('copiedTip');
+      expect(notVisibleTip).toHaveClass('opacity-0');
+
+      const button = getByRole('button', { name: /copy/i });
+      await userEvent.click(button);
+
+      const visibleCopiedTip = await findByTestId('copiedTip');
+      expect(visibleCopiedTip).toHaveClass('opacity-100');
+    });
+
   });
 
 });

--- a/src/components/TextInput/__tests__/TextInput.spec.js
+++ b/src/components/TextInput/__tests__/TextInput.spec.js
@@ -149,13 +149,13 @@ describe('Text input', () => {
       const { getByRole, queryByTestId, findByTestId } = component;
 
       const notVisibleTip = queryByTestId('copiedTip');
-      expect(notVisibleTip).toHaveClass('opacity-0');
+      expect(notVisibleTip).not.toBeInTheDocument();
 
       const button = getByRole('button', { name: /copy/i });
       await userEvent.click(button);
 
       const visibleCopiedTip = await findByTestId('copiedTip');
-      expect(visibleCopiedTip).toHaveClass('opacity-100');
+      expect(visibleCopiedTip).toBeInTheDocument();
     });
 
   });


### PR DESCRIPTION
[JIRA ticket](https://lobsters.atlassian.net/browse/DANG-432)

## Description

Adding a 'Copied' Tooltip to show above the `TextInput` for 1.5 seconds when copying the text with the `withCopyButton` copy button.

These live in the `APIKeysModal` in the dashboard; on `/address-verification` click on 'Get your Api Keys' bottom right to pop the modal.

✨ [see the new story in the preview! ](https://deploy-preview-196--elegant-yalow-f821c3.netlify.app/?path=/story/components-text-input--with-copy-button) ✨ 

https://user-images.githubusercontent.com/50080618/147152786-b7fc006a-781e-4fc1-a23e-ff5309587abb.mov


<img width="437" alt="Screen Shot 2021-12-21 at 2 18 12 PM" src="https://user-images.githubusercontent.com/50080618/146986246-36a056fe-4790-4683-994f-54caa264f360.png">

old dashboard:
<img width="392" alt="Screen Shot 2021-12-21 at 11 23 03 AM" src="https://user-images.githubusercontent.com/50080618/146986252-653448b2-f09e-4384-96f9-59000f77926c.png">

