### PR TITLE
fix the position of copied tooltip when srOnlyLabel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.159",
+  "version": "0.0.160",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -12,7 +12,8 @@
       v-if="withCopyButton"
       aria-role="alert"
       aria-live="polite"
-      class="absolute -top-4 ml-20"
+      :class="['absolute -top-4 ml-20',
+               {'-top-11': srOnlyLabel }]"
     >
       <transition
         enter-active-class="duration-1000 ease-out"


### PR DESCRIPTION
I missed a little thing in the previous PR. The absolute position of the div of the tooltip is relative to the outer TextInput div; and its height is much less when we have `srOnlyLabel` and the label is not there.

[preview link](https://deploy-preview-197--elegant-yalow-f821c3.netlify.app/?path=/story/components-text-input--with-copy-button&args=srOnlyLabel:true) `?path=/story/components-text-input--with-copy-button&args=srOnlyLabel:true`

before:
<img width="458" alt="Screen Shot 2021-12-23 at 3 55 20 PM" src="https://user-images.githubusercontent.com/50080618/147290757-c4d96a59-8e52-44bb-bce7-f25cf456c675.png">

after:
<img width="458" alt="Screen Shot 2021-12-23 at 3 55 44 PM" src="https://user-images.githubusercontent.com/50080618/147290761-ccba7939-fdb3-4204-aa89-7190788f1dbc.png">


