### PR TITLE
Subnav responsiveness quickfix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.160",
+  "version": "0.0.162",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "0.0.160",
+      "version": "0.0.162",
       "dependencies": {
         "core-js": "^3.6.5",
         "date-fns": "^2.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.161",
+  "version": "0.0.162",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/Subnavigation/Subnavigation.vue
+++ b/src/components/Subnavigation/Subnavigation.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav class="overflow-x-scroll">
+  <nav class="overflow-x-auto">
     <ul :class="`flex pb-0.5 border-b border-gray-100 ${ulClass}`">
       <slot />
     </ul>


### PR DESCRIPTION
…pear on windows machines unless content overflows

## JIRA

* [https://lobsters.atlassian.net/browse/DANG-455](https://lobsters.atlassian.net/browse/DANG-455)

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

* This relates to a prior PR, which has already been merged [https://github.com/lob/ui-components/pull/198](https://github.com/lob/ui-components/pull/198).
* The problem: on Window's machines the x scrollbar was showing even when content was not overflowing, and this was ugly.
* The solution: changed overflow-x-scroll to overflow-x-auto so bar only shows when there is actually content to scroll.

<!--
## Screenshots
- before and after screenshots for features with visual changes
-->

<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
