### PR TITLE
dang-837/add to LobLink target prop (default _self) & rel noopener noreferrer when _blank

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.162",
+  "version": "0.0.163",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/Link/Link.vue
+++ b/src/components/Link/Link.vue
@@ -2,6 +2,8 @@
   <component
     :is="tag"
     :[linkProp]="to"
+    :target="target"
+    :rel="target === '_blank' ? 'noopener noreferrer' : ''"
     :class="[
       {'underline text-primary-900' : underline},
       {'primary py-3 px-6 bg-primary-500 text-white active:bg-primary-700 disabled:bg-white-300': primary},
@@ -45,6 +47,10 @@ export default {
     underline: {
       type: Boolean,
       default: true
+    },
+    target: {
+      type: String,
+      default: '_self'
     }
   },
   computed: {


### PR DESCRIPTION
part 1 of [JIRA ticket](https://lobsters.atlassian.net/browse/DANG-837)

## Description

1. update the Link component to have a prop `target` with a default of `_self`

2. update the Link component to add the attribute `rel="noopener noreferrer"` when `target="_blank"`