### PR TITLE
dang-841/dropdown and modal bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.162",
+  "version": "0.0.164",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "0.0.162",
+      "version": "0.0.164",
       "dependencies": {
         "core-js": "^3.6.5",
         "date-fns": "^2.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.163",
+  "version": "0.0.164",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/Dropdown/Dropdown.mdx
+++ b/src/components/Dropdown/Dropdown.mdx
@@ -1,5 +1,10 @@
-import { Preview, Story, ArgsTable, PRIMARY_STORY } from '@storybook/addon-docs';
-import Dropdown from './Dropdown.vue';
+import {
+  Preview,
+  Story,
+  ArgsTable,
+  PRIMARY_STORY,
+} from "@storybook/addon-docs";
+import Dropdown from "./Dropdown.vue";
 
 # Dropdown
 
@@ -10,6 +15,7 @@ Dropdown is a stylized, accessible component that mimics the behavior of a nativ
 </Preview>
 
 ## How to Use
+
 To use the dropdown component, you must provide a `v-model`, an `id`, a `label`, and an array of `options`.
 
 The dropdown will accept `options` as an array of string or objects. If you use objects, they must have at least the `label` property and optionally the `disabled` property. When an option is selected, the dropdown will emit an `input` event with the selected option (the full string or object).
@@ -21,31 +27,61 @@ Like other input types, you can provide boolean props for `required`, `disabled`
 Customizations exist for<br />
 (1) the size of the dropdown with the `size` prop: "default" or "small"<br />
 
+(2) the height of the dropdown list
+
+The listHeight prop is available if you wanted to set a fixed height on the dropdown list, and any overflow will be scrollable. The height passed in should be in Tailwind heights, ex. listHeight="72" = class="h-72" = height: 18rem.
+
 Example of using this component in a template with simple string options
+
 ```js
-const options = ['Ginny', 'Prudence', 'Brie', 'Jenny']
-const modelValue = ''
+const options = ["Ginny", "Prudence", "Brie", "Jenny"];
+const modelValue = "";
 ```
+
 ```html
-<dropdown id="pet" v-model="modelValue" id="pet" label="Pet" :options="options" placeholder="Pick a pet" />
+<dropdown
+  id="pet"
+  v-model="modelValue"
+  id="pet"
+  label="Pet"
+  :options="options"
+  placeholder="Pick a pet"
+/>
 ```
 
 Example of the emitted event data
+
 ```js
-'Ginny'
+"Ginny";
+
 ```
 
 Example of using this component in a template with object options (for more complex use cases and to set disabled options).
 Note: only label is used in the component but the emitted event will include the entire option object
+
 ```js
-const options = [{ label: 'Ginny', value: 'Beth' }, { label: 'Prudence', value: 'Mercedes' }, { label: 'Brie', value: 'Nina' }, {label: 'Jenny', value: 'Mercedes', disabled: true }]
-const modelValue = ''
+const options = [
+  { label: "Ginny", value: "Beth" },
+  { label: "Prudence", value: "Mercedes" },
+  { label: "Brie", value: "Nina" },
+  { label: "Jenny", value: "Mercedes", disabled: true },
+];
+const modelValue = "";
 ```
+
 ```html
-<dropdown id="pet" v-model="modelValue" id="pet" label="Pet" :options="options" placeholder="Pick a pet" />
+<dropdown
+  id="pet"
+  v-model="modelValue"
+  id="pet"
+  label="Pet"
+  :options="options"
+  placeholder="Pick a pet"
+/>
 ```
 
 Example of the emitted event data
+
 ```js
 { label: 'Ginny', value: 'Beth' }
 ```

--- a/src/components/Dropdown/Dropdown.vue
+++ b/src/components/Dropdown/Dropdown.vue
@@ -57,7 +57,7 @@
         ref="listbox"
         role="listbox"
         :class="[
-          'max-h-80 bg-white rounded-sm text-sm py-4 overflow-y-auto absolute left-0 top-full hidden w-full z-50 shadow',
+          `bg-white rounded-sm text-sm py-4 overflow-y-auto absolute left-0 top-full hidden w-full z-50 shadow ${listHeight ? `h-${listHeight}` : 'max-h-80'}`,
           {'!block': open }
         ]"
       >
@@ -202,6 +202,10 @@ export default {
     error: {
       type: Boolean,
       default: false
+    },
+    listHeight: {
+      type: String,
+      default: null
     }
   },
   emits: ['update:modelValue', 'input', 'change'],

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -6,7 +6,7 @@
       @mousedown="closeModal"
     >
       <div
-        class="bg-white flex flex-col overflow-x-visible shadow rounded-lg p-5 max-h-5/6"
+        class="bg-white flex flex-col overflow-y-auto shadow rounded-lg p-5 max-h-5/6"
         role="dialog"
         aria-labelledby="modalTitle"
         aria-describedby="modalDescription"


### PR DESCRIPTION
## JIRA

* [https://lobsters.atlassian.net/browse/DANG-841](https://lobsters.atlassian.net/browse/DANG-841)

* Link to dashboard PR: [https://github.com/lob/dashboard-vue/pull/402](https://github.com/lob/dashboard-vue/pull/402)

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

* The problem: The modals/states were being 'cut off' due to not having the appropriate y overflow.  Scrolling was not possible.

<img width="478" alt="Screen Shot 2022-01-04 at 2 33 55 PM" src="https://user-images.githubusercontent.com/78509611/148113769-1b5d59a9-cdaf-446a-9ca5-b301d7e5dd40.png">

* The fix: 1. Changed overflow-x-visible to overflow-y-auto 2. Added a listHeight prop to dropdown so height can be specified if necessary (such as on state dropdown) and dropdown will become scrollable.

This PR is the first part of changes that will also be submitted in Dashboard-Vue.



<!--
## Screenshots
- before and after screenshots for features with visual changes
-->

<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
