### PR TITLE
Dang 751/collapsed nav

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.164",
+  "version": "0.0.165",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "0.0.164",
+      "version": "0.0.165",
       "dependencies": {
         "core-js": "^3.6.5",
         "date-fns": "^2.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.164",
+  "version": "0.0.165",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/MainNavigation/MainNavigation.vue
+++ b/src/components/MainNavigation/MainNavigation.vue
@@ -15,7 +15,6 @@
         { expanded: collapsible && expanded },
         { collapsed: collapsible && !expanded }
       ]"
-      @click="navClick"
     >
       <slot :expanded="expanded" />
     </ul>
@@ -47,12 +46,6 @@ export default {
     animateDrawer () {
       this.expanded = !this.expanded;
       this.$emit('toggleCollapse');
-    },
-    navClick () {
-      if (!this.expanded) {
-        this.expanded = true;
-        this.$emit('toggleCollapse');
-      }
     }
   }
 };

--- a/src/components/MainNavigation/MainNavigation.vue
+++ b/src/components/MainNavigation/MainNavigation.vue
@@ -15,6 +15,7 @@
         { expanded: collapsible && expanded },
         { collapsed: collapsible && !expanded }
       ]"
+      @click="navClick"
     >
       <slot :expanded="expanded" />
     </ul>
@@ -46,6 +47,12 @@ export default {
     animateDrawer () {
       this.expanded = !this.expanded;
       this.$emit('toggleCollapse');
+    },
+    navClick () {
+      if (!this.expanded) {
+        this.expanded = true;
+        this.$emit('toggleCollapse');
+      }
     }
   }
 };

--- a/src/components/MainNavigation/MainNavigationItem.vue
+++ b/src/components/MainNavigation/MainNavigationItem.vue
@@ -2,6 +2,7 @@
   <li class="list-none">
     <component
       :is="tag"
+      :id="id"
       :class="[
         'no-underline py-4 px-6 max-h-12 flex items-center w-full font-light text-sm text-left text-gray-500 relative overflow-hidden hover:text-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-100 focus:border-transparent'
       ]"
@@ -92,7 +93,7 @@ export default {
       default: ''
     }
   },
-  emits: ['nav'],
+  emits: ['nav', 'navItemWithChildClick'],
   data () {
     return {
       subNavOpen: this.expanded && !this.subNavCollapsed
@@ -110,7 +111,7 @@ export default {
     }
   },
   methods: {
-    toggleSubNav () {
+    toggleSubNav ($event) {
       if (this.collapsible) {
         this.subNavOpen = !this.subNavOpen;
       }

--- a/src/components/MainNavigation/MainNavigationItem.vue
+++ b/src/components/MainNavigation/MainNavigationItem.vue
@@ -12,6 +12,7 @@
       @[clickEvent]="toggleSubNav"
     >
       <img
+        :id="`img-${id}`"
         :src="iconSrc"
         :alt="iconAltText"
         class="w-6 align-bottom"
@@ -85,6 +86,10 @@ export default {
     itemClass: {
       type: String,
       default: null
+    },
+    id: {
+      type: String,
+      default: ''
     }
   },
   emits: ['nav'],
@@ -109,6 +114,9 @@ export default {
       if (this.collapsible) {
         this.subNavOpen = !this.subNavOpen;
       }
+
+      this.$emit('navItemWithChildClick', $event.target.id);
+
     },
     handleNavigation () {
       if (this.to) {

--- a/src/components/MainNavigation/MainNavigationItem.vue
+++ b/src/components/MainNavigation/MainNavigationItem.vue
@@ -9,7 +9,7 @@
       :underline="false"
       active-class="text-normal bg-white-300 font-medium"
       @click.stop="handleNavigation"
-      @[clickEvent].stop="toggleSubNav"
+      @[clickEvent]="toggleSubNav"
     >
       <img
         :src="iconSrc"
@@ -87,7 +87,7 @@ export default {
       default: null
     }
   },
-  emits: ['nav'],
+  emits: ['nav', 'subNavItemClick'],
   data () {
     return {
       subNavOpen: this.expanded && !this.subNavCollapsed
@@ -108,6 +108,10 @@ export default {
     toggleSubNav () {
       if (this.collapsible) {
         this.subNavOpen = !this.subNavOpen;
+      }
+
+      if (!this.expanded) {
+        this.$emit('subNavItemClick');
       }
     },
     handleNavigation () {

--- a/src/components/MainNavigation/MainNavigationItem.vue
+++ b/src/components/MainNavigation/MainNavigationItem.vue
@@ -87,7 +87,7 @@ export default {
       default: null
     }
   },
-  emits: ['nav', 'subNavItemClick'],
+  emits: ['nav'],
   data () {
     return {
       subNavOpen: this.expanded && !this.subNavCollapsed
@@ -108,10 +108,6 @@ export default {
     toggleSubNav () {
       if (this.collapsible) {
         this.subNavOpen = !this.subNavOpen;
-      }
-
-      if (!this.expanded) {
-        this.$emit('subNavItemClick');
       }
     },
     handleNavigation () {


### PR DESCRIPTION
## JIRA
[https://lobsters.atlassian.net/browse/DANG-751](https://lobsters.atlassian.net/browse/DANG-751)

## Description

This is part 1 of a 2 part PR, the second PR will be in dashboard-vue.

[Link to PR in dashboard
](https://github.com/lob/dashboard-vue/pull/408)

The problem: 

 * Currently, when the left navigation menu is collapsed and a user clicks either the Address Verification, Print & Mail, or API Logs icons, nothing happens.  

* This is because these are menu items with children, so they do not directly navigate the user anywhere.  
* In old Dashboard, when you click one of these options, the menu expands again with only the submenu for the item clicked expanded, showing all of the submenu items - For example, if you click the Print & Mail icon, the menu expands and ONlY the Print & Mail sub options will be expanded. 

 * To allow this, an event must be emitted from the mainNavigationItem that passes the id of the navigation item clicked.  
 
*  The id will be passed down in mainNav in the dashboard.  
* Since toggleSubNav is only fired on items that have additional items the event is emitted from that method.  
* I’ve placed id’s on both the image and the list item - this is so that the event works both when the icon is directly clicked, or when the user clicks just outside of the icon.  
* Removed the stop from the component click event so that toggleSubNav will fire, even when the icon is clicked.
