### PR TITLE
Dang 751/collapsed nav refactor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.165",
+  "version": "0.0.166",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "0.0.165",
+      "version": "0.0.166",
       "dependencies": {
         "core-js": "^3.6.5",
         "date-fns": "^2.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.165",
+  "version": "0.0.166",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/MainNavigation/MainNavigationItem.vue
+++ b/src/components/MainNavigation/MainNavigationItem.vue
@@ -2,7 +2,6 @@
   <li class="list-none">
     <component
       :is="tag"
-      :id="id"
       :class="[
         'no-underline py-4 px-6 max-h-12 flex items-center w-full font-light text-sm text-left text-gray-500 relative overflow-hidden hover:text-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-100 focus:border-transparent'
       ]"
@@ -13,7 +12,6 @@
       @[clickEvent]="toggleSubNav"
     >
       <img
-        :id="`img-${id}`"
         :src="iconSrc"
         :alt="iconAltText"
         class="w-6 align-bottom"
@@ -111,12 +109,12 @@ export default {
     }
   },
   methods: {
-    toggleSubNav ($event) {
+    toggleSubNav () {
       if (this.collapsible) {
         this.subNavOpen = !this.subNavOpen;
       }
 
-      this.$emit('navItemWithChildClick', $event.target.id);
+      this.$emit('navItemWithChildClick', this.id);
 
     },
     handleNavigation () {


### PR DESCRIPTION
## JIRA

[https://lobsters.atlassian.net/browse/DANG-751](https://lobsters.atlassian.net/browse/DANG-751)

Making refactor as suggested by peer review in dashboard PR [https://github.com/lob/dashboard-vue/pull/408](https://github.com/lob/dashboard-vue/pull/408)

$event.target.id does not need to be emitted, as id is already passed as a prop - cleaner to just emit this.id