### PR TITLE
ProgressBar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "sass-loader": "^10.1.1",
         "stylelint": "^13.13.1",
         "stylelint-config-standard": "^22.0.0",
-        "tailwind-plugin-lob": "^0.0.21",
+        "tailwind-plugin-lob": "^0.0.22",
         "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.1.4",
         "typescript": "~3.9.3",
         "vue-eslint-parser": "^7.6.0",
@@ -28345,7 +28345,9 @@
       }
     },
     "node_modules/tailwind-plugin-lob": {
-      "version": "0.0.21",
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/tailwind-plugin-lob/-/tailwind-plugin-lob-0.0.22.tgz",
+      "integrity": "sha512-AIIFdhyufnFCJdHED3SV+ldQeqvWkLJOi1zO6vC1s0nTI0I1lWiIilqimqGvMeUIrgvCKi92mT8VJwE5GKJjGg==",
       "dev": true,
       "dependencies": {
         "tailwind-plugin-lob": "^0.0.15"
@@ -52137,7 +52139,9 @@
       }
     },
     "tailwind-plugin-lob": {
-      "version": "0.0.21",
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/tailwind-plugin-lob/-/tailwind-plugin-lob-0.0.22.tgz",
+      "integrity": "sha512-AIIFdhyufnFCJdHED3SV+ldQeqvWkLJOi1zO6vC1s0nTI0I1lWiIilqimqGvMeUIrgvCKi92mT8VJwE5GKJjGg==",
       "dev": true,
       "requires": {
         "tailwind-plugin-lob": "^0.0.15"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "sass-loader": "^10.1.1",
     "stylelint": "^13.13.1",
     "stylelint-config-standard": "^22.0.0",
-    "tailwind-plugin-lob": "^0.0.21",
+    "tailwind-plugin-lob": "^0.0.22",
     "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.1.4",
     "typescript": "~3.9.3",
     "vue-eslint-parser": "^7.6.0",

--- a/src/components/ProgressBar/ProgressBar.mdx
+++ b/src/components/ProgressBar/ProgressBar.mdx
@@ -1,0 +1,33 @@
+import {
+  Preview,
+  Story,
+  ArgsTable,
+  PRIMARY_STORY,
+} from "@storybook/addon-docs";
+import ProgressBar from "./ProgressBar.vue";
+
+# ProgressBar
+
+ProgressBar is a component used in file-uploading to indicate the progress of the upload.
+
+<Preview>
+  <Story id="components-progressbar--indeterminate" />
+</Preview>
+
+## How to Use
+
+If there is no percentage given, the ProgressBar is by default indeterminate.
+
+```html
+<ProgressBar />
+```
+
+If percentage is given, the bar will grow according to it and will also display the number %.
+
+```html
+<ProgressBar :percentage="20" />
+```
+
+## Props
+
+<ArgsTable story={PRIMARY_STORY} />

--- a/src/components/ProgressBar/ProgressBar.stories.js
+++ b/src/components/ProgressBar/ProgressBar.stories.js
@@ -4,6 +4,9 @@ import mdx from './ProgressBar.mdx';
 export default {
   title: 'Components/ProgressBar',
   component: ProgressBar,
+  decorators: [
+    () => ({ template: '<div class="w-80"><story /></div>' })
+  ],
   parameters: {
     docs: {
       page: mdx
@@ -15,7 +18,7 @@ const Template = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: {  ProgressBar },
   setup: () => ({ args }),
-  template: '<ProgressBar class="w-80 m-auto" v-bind="args" />'
+  template: '<ProgressBar v-bind="args" />'
 });
 
 export const Indeterminate = Template.bind({});

--- a/src/components/ProgressBar/ProgressBar.stories.js
+++ b/src/components/ProgressBar/ProgressBar.stories.js
@@ -4,9 +4,6 @@ import mdx from './ProgressBar.mdx';
 export default {
   title: 'Components/ProgressBar',
   component: ProgressBar,
-  decorators: [
-    () => ({ template: '<div class="w-80"><story /></div>' })
-  ],
   parameters: {
     docs: {
       page: mdx

--- a/src/components/ProgressBar/ProgressBar.stories.js
+++ b/src/components/ProgressBar/ProgressBar.stories.js
@@ -1,0 +1,27 @@
+import ProgressBar from './ProgressBar.vue';
+import mdx from './ProgressBar.mdx';
+
+export default {
+  title: 'Components/ProgressBar',
+  component: ProgressBar,
+  parameters: {
+    docs: {
+      page: mdx
+    }
+  }
+};
+
+const Template = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: {  ProgressBar },
+  setup: () => ({ args }),
+  template: '<ProgressBar class="w-80 m-auto" v-bind="args" />'
+});
+
+export const Indeterminate = Template.bind({});
+
+export const WithPercentage = Template.bind({});
+WithPercentage.args = {
+  percentage: 25
+};
+

--- a/src/components/ProgressBar/ProgressBar.stories.js
+++ b/src/components/ProgressBar/ProgressBar.stories.js
@@ -4,6 +4,9 @@ import mdx from './ProgressBar.mdx';
 export default {
   title: 'Components/ProgressBar',
   component: ProgressBar,
+  decorators: [
+    () => ({ template: '<div style="width: 20rem;"><story /></div>' })
+  ],
   parameters: {
     docs: {
       page: mdx

--- a/src/components/ProgressBar/ProgressBar.vue
+++ b/src/components/ProgressBar/ProgressBar.vue
@@ -24,7 +24,7 @@
         >.</span>
       </span>
     </div>
-    <div class="mt-2 h-1.5 w-80 bg-gray-100 flex">
+    <div class="mt-2 h-1.5 bg-gray-100 flex">
       <span
         data-testid="innerbar"
         :style="percentage ? `width: ${percentage}%` : ''"

--- a/src/components/ProgressBar/ProgressBar.vue
+++ b/src/components/ProgressBar/ProgressBar.vue
@@ -27,7 +27,7 @@
     <div class="mt-2 h-1.5 w-80 bg-gray-100 flex">
       <span
         data-testid="innerbar"
-        :style="percentage?`width:${percentage}%`:''"
+        :style="percentage ? `width: ${percentage}%` : ''"
         :class="['h-1.5 bg-turquoise-500 transition-all duration-500 ease-out',
                  {'animate-indybar bg-gradient-to-r from-turquoise-300 to-turquoise-500': !percentage}]"
       />
@@ -39,10 +39,13 @@
 export default {
   name: 'ProgressBar',
   props: {
-    percentage: { type: Number, default: 0,
+    percentage: {
+      type: Number,
+      default: 0,
       validator (value) {
         return value >= 0 && value <= 100;
-      } }
+      }
+    }
   }
 };
 </script>

--- a/src/components/ProgressBar/ProgressBar.vue
+++ b/src/components/ProgressBar/ProgressBar.vue
@@ -24,7 +24,7 @@
         >.</span>
       </span>
     </div>
-    <div class="mt-2 h-1.5 bg-gray-100 flex">
+    <div class="mt-2 h-1.5 w-full bg-gray-100 flex">
       <span
         data-testid="innerbar"
         :style="percentage?`width:${percentage}%`:''"

--- a/src/components/ProgressBar/ProgressBar.vue
+++ b/src/components/ProgressBar/ProgressBar.vue
@@ -52,7 +52,7 @@ export default {
         pb.setAttribute('aria-valuenow', this.percentage);
         pb.setAttribute('aria-valuenmin', 0);
         pb.setAttribute('aria-valuemax', 100);
-        pb.setAttribute('aria-busy', true);
+        pb.setAttribute('aria-busy', this.percentage === 100 ? false : true);
         pb.setAttribute('aria-valuetext', `In progress, ${this.percentage}%`);
       }
     }

--- a/src/components/ProgressBar/ProgressBar.vue
+++ b/src/components/ProgressBar/ProgressBar.vue
@@ -1,12 +1,10 @@
 <template>
   <div
+    ref="progressbar"
     role="progressbar"
     title="Progress"
     aria-live="polite"
-    :aria-valuenow="percentage ? percentage : ''"
-    :aria-valuemin="percentage ? 0 : ''"
-    :aria-valuemax="percentage ? 100 : ''"
-    :aria-busy="percentage > 0 && percentage < 100"
+    aria-valuetext="In progress, please wait"
     class="text-left"
   >
     <div>
@@ -44,6 +42,18 @@ export default {
       default: 0,
       validator (value) {
         return value >= 0 && value <= 100;
+      }
+    }
+  },
+  watch: {
+    percentage (value) {
+      if (value > 0) {
+        const pb = this.$refs.progressbar;
+        pb.setAttribute('aria-valuenow', this.percentage);
+        pb.setAttribute('aria-valuenmin', 0);
+        pb.setAttribute('aria-valuemax', 100);
+        pb.setAttribute('aria-busy', true);
+        pb.setAttribute('aria-valuetext', `In progress, ${this.percentage}%`);
       }
     }
   }

--- a/src/components/ProgressBar/ProgressBar.vue
+++ b/src/components/ProgressBar/ProgressBar.vue
@@ -1,0 +1,56 @@
+<template>
+  <div
+    role="progressbar"
+    title="Progress"
+    aria-live="polite"
+    :aria-valuenow="percentage ? percentage : ''"
+    :aria-valuemin="percentage ? 0 : ''"
+    :aria-valuemax="percentage ? 100 : ''"
+    :aria-busy="percentage > 0 && percentage < 100"
+    class="text-left"
+  >
+    <div>
+      Progress
+      <span v-if="percentage"> - {{ percentage }}%</span>
+      <span
+        v-else
+        data-testid="dots"
+      >
+        <span
+          v-for="dot in 3"
+          :key="dot"
+          aria-hidden="true"
+          class="dots animate-ping ml-0.5"
+        >.</span>
+      </span>
+    </div>
+    <div class="mt-2 h-1.5 bg-gray-100 flex">
+      <span
+        data-testid="innerbar"
+        :style="percentage?`width:${percentage}%`:''"
+        :class="['h-1.5 bg-turquoise-500 transition-all duration-500 ease-out',
+                 {'animate-indybar bg-gradient-to-r from-turquoise-300 to-turquoise-500': !percentage}]"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ProgressBar',
+  props: {
+    percentage: { type: Number, default: 0,
+      validator (value) {
+        return value >= 0 && value <= 100;
+      } }
+  }
+};
+</script>
+
+<style scoped lang="scss">
+.dots {
+  animation-duration: 2s;
+  &:nth-child(2) { animation-delay: 0.4s; }
+  &:nth-child(3) { animation-delay: 0.8s; }
+}
+</style>

--- a/src/components/ProgressBar/ProgressBar.vue
+++ b/src/components/ProgressBar/ProgressBar.vue
@@ -7,7 +7,7 @@
     :aria-valuemin="percentage ? 0 : ''"
     :aria-valuemax="percentage ? 100 : ''"
     :aria-busy="percentage > 0 && percentage < 100"
-    class="text-left"
+    class="text-left w-full"
   >
     <div>
       Progress

--- a/src/components/ProgressBar/ProgressBar.vue
+++ b/src/components/ProgressBar/ProgressBar.vue
@@ -7,7 +7,7 @@
     :aria-valuemin="percentage ? 0 : ''"
     :aria-valuemax="percentage ? 100 : ''"
     :aria-busy="percentage > 0 && percentage < 100"
-    class="text-left w-full"
+    class="text-left"
   >
     <div>
       Progress
@@ -24,7 +24,7 @@
         >.</span>
       </span>
     </div>
-    <div class="mt-2 h-1.5 w-full bg-gray-100 flex">
+    <div class="mt-2 h-1.5 w-80 bg-gray-100 flex">
       <span
         data-testid="innerbar"
         :style="percentage?`width:${percentage}%`:''"

--- a/src/components/ProgressBar/__tests__/ProgressBar.spec.js
+++ b/src/components/ProgressBar/__tests__/ProgressBar.spec.js
@@ -48,4 +48,31 @@ describe('ProgressBar', () => {
 
   });
 
+  describe('test the watcher that adds aria attributes', () => {
+
+    let component;
+    beforeEach(() => {
+      component = renderComponent({ props: { percentage: 0 } });
+    });
+
+    it('starting with percentage: 0, it does not have aria-busy', async () => {
+      const { findByRole } = component;
+
+      const progressbar = await findByRole('progressbar');
+      expect(progressbar).not.toHaveAttribute('aria-busy');
+    });
+
+    it('adds the aria attributes when the percentage changes', async () => {
+      const { rerender, findByRole } = component;
+      await rerender({ percentage: 35 });
+
+      const progressbar = await findByRole('progressbar');
+      expect(progressbar).toHaveAttribute('aria-busy', 'true');
+      expect(progressbar).toHaveAttribute('aria-valuenow', '35');
+      expect(progressbar).toHaveAttribute('aria-valuemax', '100');
+      expect(progressbar).toHaveAttribute('aria-valuetext', 'In progress, 35%');
+    });
+
+  });
+
 });

--- a/src/components/ProgressBar/__tests__/ProgressBar.spec.js
+++ b/src/components/ProgressBar/__tests__/ProgressBar.spec.js
@@ -1,0 +1,51 @@
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/vue';
+import ProgressBar from '../ProgressBar.vue';
+
+const renderComponent = (options) => render(ProgressBar, { ...options });
+
+describe('ProgressBar', () => {
+
+  describe('Indeterminate', () => {
+
+    it('renders Progress and the dots', () => {
+      const { queryByText, queryByTestId } = renderComponent();
+
+      const progress = queryByText(/Progress/i);
+      const dots = queryByTestId('dots');
+      expect(progress).toBeInTheDocument();
+      expect(dots).toBeInTheDocument();
+    });
+
+    it('the inner bar has the indybar class', () => {
+      const { queryByTestId } = renderComponent();
+
+      const innerbar = queryByTestId('innerbar');
+      expect(innerbar).toHaveClass('animate-indybar');
+    });
+
+  });
+
+  describe('With percentage', () => {
+
+    const props = { percentage: 25 };
+
+    it('renders Progress and the percentage', () => {
+      const { queryByText } = renderComponent({ props });
+
+      const progress = queryByText(/Progress/i);
+      expect(progress).toBeInTheDocument();
+      const percentage = queryByText(/- 25%/i);
+      expect(percentage).toBeInTheDocument();
+    });
+
+    it('the inner bar does not have the indybar class', () => {
+      const { queryByTestId } = renderComponent({ props });
+
+      const innerbar = queryByTestId('innerbar');
+      expect(innerbar).not.toHaveClass('animate-indybar');
+    });
+
+  });
+
+});


### PR DESCRIPTION
made for the FileUploader ([Jira link](https://lobsters.atlassian.net/browse/DANG-223)) ([figma](https://www.figma.com/file/hGGnuNxd58NEnAuGkwXckx/Lob-Dashboard---PMAPI---List-Loader?node-id=2589%3A17076))

**[Demo on Storybook](https://deploy-preview-204--elegant-yalow-f821c3.netlify.app/?path=/story/components-progressbar--indeterminate)** 

The bar can be indeterminate, or show the actual percentage if the number is passed in.
**Props:** percentage, by default 0/falsy

<img width="416" alt="Screen Shot 2022-01-28 at 8 51 34 AM" src="https://user-images.githubusercontent.com/50080618/151558418-ea88256e-748f-4352-af2a-48ee7004a637.png">

<img width="416" alt="Screen Shot 2022-01-28 at 8 51 39 AM" src="https://user-images.githubusercontent.com/50080618/151558413-70630dfd-2d59-4e4e-a92c-15f6ec72f669.png">

I made a custom bar and did not use the html `<progress/>` tag because it is really hard to style. It is probably doable but would take a lot of css & a lot of special selecting, it is not doable with TW.

**ARIA**
Aria tags info [here](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_progressbar_role) and [here](https://www.w3.org/TR/wai-aria-1.1/#progressbar)

**Animation**
The `indybar` animation was [added to the TW plugin](https://github.com/lob/tailwind-plugin-lob/commit/ceca64c0e0a1c986cb85269fce209ee3955787bf) and used here as `animate-indybar`
The dots use the TW default `ping` animation 

**Ignore the commits about width**
I had trouble getting it to demo properly - On local preview it displayed ok with the width being passed from outside as TW class, but it didn't work on the storybook demo, it showed at min width.
solution: fix a style block on the decorator! There is a comment on another component that PurgeCSS removes classes so we have to hardcode the style for the story

<hr>

a demo with a fake timer bumping the percentage to show that transition 
 
https://user-images.githubusercontent.com/50080618/151559133-96e91bb1-760d-42ec-9bfa-180756fd438f.mov

