### PR TITLE
Align SwitchGroup's legend with other form input labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.170",
+  "version": "0.0.171",
   "engines": {
     "node": "14.16.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.168",
+  "version": "0.0.169",
   "engines": {
     "node": "14.16.1"
   },

--- a/src/components/Switch/SwitchGroup.vue
+++ b/src/components/Switch/SwitchGroup.vue
@@ -2,7 +2,7 @@
   <fieldset
     role="radiogroup"
   >
-    <legend :class="[{'text-sm font-normal normal-case tracking-normal text-gray-500 mb-1 border-b-0': !srOnlyLegend}, {'sr-only': srOnlyLegend}]">
+    <legend :class="[{'text-sm font-normal normal-case tracking-normal text-gray-500 mb-2 border-b-0': !srOnlyLegend}, {'sr-only': srOnlyLegend}]">
       {{ legend }}
     </legend>
     <div :class="['shadow flex flex-wrap p-1 bg-white rounded', { 'justify-center': center }]">

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -22,6 +22,7 @@ export { default as MegaMenuSubtitle } from './MegaMenu/MegaMenuSubtitle';
 export { default as Modal } from './Modal/Modal';
 export { default as Multiselect } from './Multiselect/Multiselect';
 export { default as Pagination } from './Pagination/Pagination';
+export { default as ProgressBar } from './ProgressBar/ProgressBar';
 export { default as RadioButton } from './RadioButton/RadioButton';
 export { default as RadioGroup } from './RadioGroup/RadioGroup';
 export { default as SearchBar } from './SearchBar/SearchBar';


### PR DESCRIPTION
## Description

While working on the new List Loader feature, I wanted to utilize the Switch component in a form, side-by-side with the DateInput component. In doing so, I realized that the labels/legends don't really line up. This PR ensures that Switch's legend visually lines up with other form inputs. 

[Original PR/convo](https://github.com/lob/dashboard-vue/pull/449#discussion_r800981960)

## Screenshots

Before:
<img width="641" alt="Screen Shot 2022-02-09 at 10 06 48 AM" src="https://user-images.githubusercontent.com/5231072/153241861-1b5a41e2-eac2-489e-866a-002ef0bed917.png">

After:
<img width="625" alt="Screen Shot 2022-02-09 at 10 06 39 AM" src="https://user-images.githubusercontent.com/5231072/153241916-558832cc-fdbf-41aa-a4d3-a4ea468dcad3.png">

UI where it will be used!
<img width="824" alt="Screen Shot 2022-02-09 at 10 15 14 AM" src="https://user-images.githubusercontent.com/5231072/153242407-e9a4bce4-1323-47af-a7f2-a14c0428a14c.png">

