### PR TITLE
Fixes Array Test

### DIFF
--- a/src/utils/__tests__/array.test.js
+++ b/src/utils/__tests__/array.test.js
@@ -18,7 +18,7 @@ describe('array utils', () => {
       const subject = null;
       expect(() => {
         subject.findLastIndex((el) => el === 'a');
-      }).toThrow('Cannot read property \'findLastIndex\' of null');
+      }).toThrow();
     });
 
     it('throws an error when the predicate is not a function', () => {
@@ -26,6 +26,12 @@ describe('array utils', () => {
       expect(() => {
         subject.findLastIndex('a');
       }).toThrow();
+    });
+
+    it('returns the index of the only element that satisfies the predicate', () => {
+      const subject = ['a', 'b', 'c'];
+      const index = subject.findLastIndex((el) => el === 'a');
+      expect(index).toEqual(0);
     });
 
     it('returns the last index of an element that satisfies the predicate', () => {


### PR DESCRIPTION
## Description

Tests for ui-components were failing on main (check out [ui-components/actions](https://github.com/lob/ui-components/actions)), apparently since https://github.com/lob/ui-components/pull/211.

This is because the test itself was dependant on the underlying Node version. I explain: the error thrown by Node when trying to access a let's say `b` property of a null object changed from `Uncaught TypeError: Cannot read property 'b' of null` to `TypeError: Cannot read properties of null (reading 'b')`. You can try it yourself online with different Node versions [here](https://www.jdoodle.com/execute-nodejs-online/).

This PR removes the error's text, and just checks an error is thrown. *If you know of a more specific assessment to make, please tell*.