### PR TITLE
DANG-994: migrate to GitHub actions

### DIFF
--- a/.github/workflows/build-test-lint.yml
+++ b/.github/workflows/build-test-lint.yml
@@ -1,0 +1,82 @@
+name: Node Build / Test / Lint
+
+# Run this when someone pushes a branch
+on: [push]
+
+jobs:
+  # Get the versions of node and npm as defined in the package.json engines
+  get-versions:
+    # Running on Lob's GitHub runners
+    runs-on: [self-hosted, Linux, x64, lob-runner]
+
+    outputs:
+      node_version: ${{ steps.node_version.outputs.prop }}
+      npm_version: ${{ steps.npm_version.outputs.prop }}
+
+    steps:
+    - name: Read node version from package.json
+      id: node_version
+      uses: notiz-dev/github-action-json-property@release
+      with:
+        path: "package.json"
+        prop_path: "engines.node"
+
+    - run: |
+        echo "Node version found: ${{ steps.node_version.outputs.prop }}"
+
+    - name: Read npm version from package.json
+      id: npm_version
+      uses: notiz-dev/github-action-json-property@release
+      with:
+        path: "package.json"
+        prop_path: "engines.npm"
+
+    - run: |
+        echo "npm version found: ${{ steps.npm_version.outputs.prop }}"
+
+  # Run lint and tests
+  run-tests:
+    # Running on Lob's GitHub runners
+    runs-on: [self-hosted, Linux, x64, lob-runner]
+
+    needs: get-versions
+
+    env:
+      NODE_VERSION: ${{ needs.get-versions.outputs.node_version }}
+      NPM_VERSION: ${{ needs.get-versions.outputs.npm_version }}
+      # Used to checkout the Lob Github Actions repo
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - uses: actions/checkout@v2
+        with:
+          repository: lob/github-actions
+          ref: main
+          token: "${{ secrets.PRIVATE_GITHUB_ACTION_TOKEN }}"
+          path: ./.github/lob
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      # Setup node with the set node version. This step will use the cache specified in the actions/cache step.
+      - name: Use Node ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      # Runs the node lint / test jobs
+      - id: node_suite
+        name: Running the install, lint, and test commands with npm ${{ env.NPM_VERSION }}
+        uses: "./.github/lob/actions/node-lint-test"
+        with:
+          npm_version: ${{ env.NPM_VERSION }}
+          npm_token: ${{ env.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,31 +1,70 @@
 name: NPM Publish
+
 on:
-  push:
+  workflow_run:
+    workflows: ["Node Build / Test / Lint"]
     branches: [main]
+    types:
+      - completed
+
 jobs:
-  publish:
-    runs-on: ubuntu-latest
+  # Get the version of node as defined in the package.json engines
+  get-versions:
+    # Running on Lob's GitHub runners
+    runs-on: [self-hosted, Linux, x64, lob-runner]
+
+    outputs:
+      node_version: ${{ steps.node_version.outputs.prop }}
+
     steps:
-      - uses: actions/checkout@v2
-      - name: Read node version from package.json
-        id: node_version
-        uses: notiz-dev/github-action-json-property@release
+    - name: Read node version from package.json
+      id: node_version
+      uses: notiz-dev/github-action-json-property@release
+      with:
+        path: "package.json"
+        prop_path: "engines.node"
+
+    - run: |
+        echo "Node version found: ${{ steps.node_version.outputs.prop }}"
+
+  # Publish package to npm
+  publish:
+    # Only run if the "Node Build / Test / Lint" workflow ran on the main branch and completed successfully
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    # Running on Lob's GitHub runners
+    runs-on: [self-hosted, Linux, x64, lob-runner]
+
+    needs: get-versions
+
+    env:
+      NODE_VERSION: ${{ needs.get-versions.outputs.node_version }}
+      # Used to publish the package to the npm registry
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Setup node. This step will use the cache specified in the actions/cache step in the build-test-lint workflow.
+      - name: Use Node ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v2
         with:
-          path: "package.json"
-          prop_path: "engines.node"
-      - run: |
-          echo "Node version found: ${{ steps.node_version.outputs.prop }}"
-      - uses: actions/setup-node@v2
-        with:
-          node-version: ${{ steps.node_version.outputs.prop }}
-      - run: npm install
-      - run: npm run lint
-      - run: npm run test:unit
-      - run: npm run build-library
-      - id: publish
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Build the package
+        run: |
+          npm ci
+          npm run build-library
+
+      - name: Publish the package
+        id: publish
         uses: JS-DevTools/npm-publish@v1
         with:
-          token: ${{ secrets.NPM_TOKEN }}
+          token: ${{ env.NPM_TOKEN }}
+
       - if: steps.publish.outputs.type != 'none'
         run: |
           echo "Version changed: ${{ steps.publish.outputs.old-version }} => ${{ steps.publish.outputs.version }}"

--- a/package.json
+++ b/package.json
@@ -2,18 +2,21 @@
   "name": "@lob/ui-components",
   "version": "0.0.173",
   "engines": {
-    "node": ">=14.16.1"
+    "node": ">=14.16.1",
+    "npm": ">=7.13.0"
   },
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "test:unit": "vue-cli-service test:unit",
-    "lint": "npm run lint:js && npm run lint:css",
-    "lint-fix": "vue-cli-service lint --fix",
     "build-library": "vue-cli-service build --target lib --name ui-components src/main.js",
     "build-storybook": "build-storybook",
+    "lint": "npm run lint:js && npm run lint:css",
+    "lint-fix": "vue-cli-service lint --fix",
     "lint:css": "stylelint 'src/**/*.vue'",
     "lint:js": "eslint --ext .js,.vue .",
+    "test": "npm run test:ci",
+    "test:ci": "npm run test:unit",
+    "test:unit": "vue-cli-service test:unit",
     "storybook": "start-storybook -p 6006"
   },
   "main": "./dist/ui-components.umd.min.js",


### PR DESCRIPTION
## JIRA

[DANG-994](https://lobsters.atlassian.net/browse/DANG-994)

## Description

Migrating this repo over from CircleCi to using GitHub Actions for its CI/CD workflows.  This repo was already using a GitHub Action to publish to npm so this is just adding a workflow for running lint and tests and then making the publish workflow depending on the lint and tests workflow completing successfully.