### PR TITLE
add CSS to SwitchItem disabled state to make it more clear to the user

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.174",
+  "version": "0.0.175",
   "engines": {
     "node": ">=14.16.1",
     "npm": ">=7.13.0"

--- a/src/components/Switch/SwitchGroup.stories.js
+++ b/src/components/Switch/SwitchGroup.stories.js
@@ -35,6 +35,25 @@ Primary.args = {
   srOnlyLegend: true
 };
 
+const WithDisabledTemplate = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { SwitchGroup, SwitchItem },
+  data: () => ({ switchModel }),
+  setup: () => ({ args }),
+  template: `
+    <switch-group v-bind="args">
+      <switch-item name="mode" label="Test" value="test" v-model="switchModel" />
+      <switch-item name="mode" label="Live" value="live" v-model="switchModel" disabled />
+    </switch-group>
+  `
+});
+
+export const WithDisabled = WithDisabledTemplate.bind({});
+WithDisabled.args = {
+  legend: 'Environment mode',
+  srOnlyLegend: true
+};
+
 const withIconsModel = 'map';
 
 const WithIconsTemplate = (args, { argTypes }) => ({

--- a/src/components/Switch/SwitchItem.vue
+++ b/src/components/Switch/SwitchItem.vue
@@ -2,7 +2,8 @@
   <div
     :class="[
       'rounded flex bg-white text-gray-500',
-      { '!bg-primary-500 !text-white checked': checked }
+      { '!bg-primary-500 !text-white checked': checked },
+      { '!bg-white-300': disabled }
     ]"
   >
     <input
@@ -18,7 +19,10 @@
     >
     <label
       :for="value"
-      class="px-6 py-1.5 cursor-pointer"
+      :class="[
+        'px-6 py-1.5 cursor-pointer',
+        { 'cursor-not-allowed': disabled }
+      ]"
     >
       <span :class="[{'sr-only': srOnlyLabel}]">
         {{ label }}


### PR DESCRIPTION
## JIRA

* N/A, but needed for [DANG-1036](https://lobsters.atlassian.net/browse/DANG-1036)

## Description

* We'd like to disable the "Set Target Delivery Date" SwitchItem in the campaigns workflow for now, since we'll be launching the beta without it. _However_, as our SwitchItem stands now, the only thing that this means is that when you click on the disabled choice, ... nothing happens.
* This adds our disabled background color that we use elsewhere (e.g. buttons) + a cursor-not-allowed class to make it clear that you can't click on it.

## Screenshots

![Screen Shot 2022-03-25 at 9 47 29 AM](https://user-images.githubusercontent.com/20443660/160155152-e93a1e98-17d9-439b-9ba9-a66f4bc231b4.png)

(unfortunately this screenshot doesn't show the 🚫  cursor, but we have Netlify previews for that)

## Tests

* heh, so we have a test that checks that the input itself is disabled. I spent a few minutes trying to pull the label specifically to check that `cursor-not-allowed` was added, but was not successful. In the interest of other higher priority items right now and our test coverage in this repo not struggling, I created [a separate ticket](https://lobsters.atlassian.net/browse/DANG-1048) to go back to this when things have calmed down a bit.