### PR TITLE
dang-1058/fix: remove display:none from tooltip content container to fix glitch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.175",
+  "version": "0.0.176",
   "engines": {
     "node": ">=14.16.1",
     "npm": ">=7.13.0"

--- a/src/components/Tooltip/Tooltip.vue
+++ b/src/components/Tooltip/Tooltip.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="relative">
     <div
-      :class="['absolute', { 'hidden': !hover }]"
+      class="absolute"
       :style="tooltipPositionStyle"
     >
       <div


### PR DESCRIPTION
## JIRA

[dang-1058 glitchy tooltip icon in US Verifications view](https://lobsters.atlassian.net/browse/DANG-1058) 

## Description

The tooltip seems to glitch terribly when sitting in flex with justify-between. I cannot explain why exactly this only happens in justify between 🤨 
But it seems to be an issue with 'hidden' (which is TW for display:none = removing element from the DOM)
I tried auto margins, fixed height, other things - on the dashboard side - but none seems to work.

The outer div of the tooltip content is using the hidden property but it does not need it, as the content div uses opacity to hide/show the content. Removing this fixes the problem with the flex display.

**Demos:
with hidden**

https://user-images.githubusercontent.com/50080618/160868574-9bffe30a-ad9a-4fee-b034-57efecaccee4.mov

**without hidden:**

https://user-images.githubusercontent.com/50080618/160868556-0b58c2f5-c173-4461-ac4b-45611ef0954c.mov

