### PR TITLE
Dang 1031/Restyle of Switch component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.177",
+  "version": "0.0.178",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/Switch/SwitchItem.vue
+++ b/src/components/Switch/SwitchItem.vue
@@ -1,8 +1,8 @@
 <template>
   <div
     :class="[
-      'rounded flex bg-white text-gray-500',
-      { '!bg-primary-500 !text-white checked': checked },
+      'rounded-sm flex bg-white text-primary-500 font-thin',
+      { '!bg-primary-500 !text-white checked font-semibold': checked },
       { '!bg-white-300': disabled }
     ]"
   >
@@ -20,7 +20,7 @@
     <label
       :for="value"
       :class="[
-        'px-6 py-1.5 cursor-pointer',
+        'px-5 py-1.5 cursor-pointer',
         { 'cursor-not-allowed': disabled }
       ]"
     >


### PR DESCRIPTION
## JIRA

[DANG-1031 Restyle of Switch component](https://lobsters.atlassian.net/browse/DANG-1031)

[figma](https://www.figma.com/file/h2T4pIQzH1M17LFGXMbJ4u/Design-System-(Blendr)-Hand-Off?node-id=139%3A1399)

### [Preview link](https://deploy-preview-219--elegant-yalow-f821c3.netlify.app/?path=/story/components-switch-group--primary)

## Description

Restyle the Switch as per figma: 
- SwitchItem changes: slightly less px/width, less rounded corners, default font thin & blue, active item font semi-bold, 
- SwitchGroup gets a new shadow ✨ 

default `shadow` [changed in TW plugin](https://github.com/lob/tailwind-plugin-lob/pull/15)

**old:**
<img width="299" alt="Screen Shot 2022-03-31 at 10 44 13 AM" src="https://user-images.githubusercontent.com/50080618/161089362-f2344d90-0e55-4b05-9219-94a2f7ec8f0b.png">
**new:**
<img width="299" alt="Screen Shot 2022-03-31 at 10 44 06 AM" src="https://user-images.githubusercontent.com/50080618/161089364-f158465e-cdc6-4709-be9a-0532b92c4a6f.png">

