### PR TITLE
Fix package breaking in version 0.0.179

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.177",
+  "version": "0.0.180",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "0.0.177",
+      "version": "0.0.180",
       "dependencies": {
         "date-fns": "^2.23.0",
         "mitt": "^3.0.0",
@@ -54,6 +54,7 @@
         "npm": ">=8.3.0"
       },
       "peerDependencies": {
+        "vue": "^3.0.0",
         "vue-i18n": "^9.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "vue-style-loader": "^4.1.3"
   },
   "peerDependencies": {
+    "vue": "^3.0.0",
     "vue-i18n": "^9.0.0"
   },
   "browserslist": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.179",
+  "version": "0.0.180",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/vite.config.js
+++ b/vite.config.js
@@ -17,6 +17,7 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './src')
     },
+    dedupe: ['vue'],
     extensions: ['.mjs', '.js', '.ts', '.jsx', '.tsx', '.json', '.vue']
   },
   rollupOptions: {
@@ -29,6 +30,9 @@ export default defineConfig({
       globals: {
         vue: 'Vue'
       }
+    },
+    resolve: {
+      dedupe: ['vue']
     }
   },
   test: {


### PR DESCRIPTION
The latest updates to use vite to build this package required additional configuration in order to prevent Vue from being bundled in the package.  Trying to update Dashboard to use the latest version 0.0.179 is breaking Dashboard.  This should remove the bundling of Vue in the package.