### PR TITLE
Fix css export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.181",
+  "version": "0.0.182",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "0.0.181",
+      "version": "0.0.182",
       "dependencies": {
         "date-fns": "^2.23.0",
         "mitt": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.181",
+  "version": "0.0.182",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     ".": {
       "import": "./dist/ui-components.es.js",
       "require": "./dist/ui-components.umd.js"
-    }
+    },
+    "./dist/ui-components.css": "./dist/style.css"
   },
   "scripts": {
     "build": "vite build",


### PR DESCRIPTION
When trying to import the latest version of this library after switching to building with vite we get an error on line:
```
import '@lob/ui-components/dist/ui-components.css';
```

Stating
> Missing "./dist/ui-components.css" export in "@lob/ui-components" package

Even changing to import `style.css` doesn't fix it because we haven't specified that the `css` file be exported in the package.  This adds the file to the included exports.