### PR TITLE
newbutton updates: fixed height, letter-spacing, focus-visible, small size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.186",
+  "version": "0.0.187",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/NewButton/NewButton.mdx
+++ b/src/components/NewButton/NewButton.mdx
@@ -22,18 +22,20 @@ You can change the variant of the button by adding the `variant` prop (String) t
 
 The Button is regular size by default (height: 48px) & can be made small (32px) with the `small` prop (boolean).
 
-Please note: though you can only insert text in the Storybook demo, the button component will accept any valid HTML or Vue component.
+The `warning` prop (Boolean) will change the button color to dark red if primary, and red outline if secondary.
+
+Please note: though you can only insert text in the Storybook demo, the button component will accept any valid HTML or Vue component, as it uses a slot.
 
 Example of using this component as a primary button in a template
 
 ```html
-<new-button> This is a button </new-button>
+<new-button> This is a primary button </new-button>
 ```
 
 Example of using this component as a secondary button in a template
 
 ```html
-<new-button variant="secondary"> This is a button </new-button>
+<new-button variant="secondary"> This is a secondary button </new-button>
 ```
 
 ## Props

--- a/src/components/NewButton/NewButton.mdx
+++ b/src/components/NewButton/NewButton.mdx
@@ -20,7 +20,7 @@ There are 2 variants of buttons: 'primary' & 'secondary'; as well as 'link' and 
 
 You can change the variant of the button by adding the `variant` prop (String) to the component.
 
-The Button is regular size by default (height: 48px) & can be made small (32px) with the `small` prop (boolean).
+The Button can be regular size (default, height: 48px) & or small (32px) with the `small` prop (Boolean).
 
 The `warning` prop (Boolean) will change the button color to dark red if primary, and red outline if secondary.
 

--- a/src/components/NewButton/NewButton.mdx
+++ b/src/components/NewButton/NewButton.mdx
@@ -16,9 +16,11 @@ Buttons are styled semantic buttons that will handle all of the appropriate butt
 
 ## How to Use
 
-There are 2 variants of buttons: 'primary' & 'secondary'.
+There are 2 variants of buttons: 'primary' & 'secondary'; as well as 'link' and 'none' styles.
 
-You can change the variant of the button by adding the `variant` prop to the component.
+You can change the variant of the button by adding the `variant` prop (String) to the component.
+
+The Button is regular size by default (height: 48px) & can be made small (32px) with the `small` prop (boolean).
 
 Please note: though you can only insert text in the Storybook demo, the button component will accept any valid HTML or Vue component.
 

--- a/src/components/NewButton/NewButton.stories.js
+++ b/src/components/NewButton/NewButton.stories.js
@@ -33,6 +33,11 @@ export default {
       control: {
         type: 'boolean'
       }
+    },
+    small: {
+      control: {
+        type: 'boolean'
+      }
     }
   }
 };

--- a/src/components/NewButton/NewButton.vue
+++ b/src/components/NewButton/NewButton.vue
@@ -1,13 +1,15 @@
 <template>
   <button
     :class="[
-      'flex justify-center items-center rounded-lg focus:ring-4 focus:outline-none',
-      { 'px-8 py-2.5 font-bold textTwenty': primary || secondary },
-      { 'p-0 text-primary-500 underline disabled:text-gray-500': link },
-      { 'p-0 disabled:text-gray-500': none },
+      'flex justify-center items-center rounded-lg tracking-[-0.04em] focus-visible:ring-4 focus-visible:outline-none',
+      { 'font-bold': primary || secondary },
+      { 'px-8 text-[20px] h-[48px]': regular },
+      { 'px-6 text-[14px] h-[32px]': small },
+      { 'p-0 text-base text-primary-500 underline disabled:text-gray-500': link },
+      { 'p-0 text-base disabled:text-gray-500': none },
       { 'cursor-not-allowed': disabled },
-      { 'focus:ring-primary-100': !warning },
-      { 'focus:ring-coral-700': warning },
+      { 'focus-visible:ring-primary-100': !warning },
+      { 'focus-visible:ring-coral-700': warning },
       { 'primary  bg-primary-500 text-white active:bg-black disabled:bg-gray-100': primary && !warning },
       { 'primary warning bg-coral-900 text-white active:bg-coral-700 disabled:bg-coral-200': primary && warning },
       { 'secondary border border-primary-500 bg-white text-primary-500': secondary && !warning,
@@ -35,6 +37,10 @@ export default {
         return ['primary', 'secondary', 'link', 'none'].includes(value);
       }
     },
+    small: {
+      type: Boolean,
+      default: false
+    },
     disabled: {
       type: Boolean,
       default: false
@@ -57,6 +63,9 @@ export default {
     },
     none () {
       return this.variant === 'none';
+    },
+    regular () {
+      return !this.small;
     }
   },
   methods: {
@@ -72,26 +81,26 @@ export default {
   font-size: 20px;
 }
 
-.primary:focus:not(:active):not(:disabled),
-.primary:hover:not(:disabled):not(:focus) {
+.primary:focus-visible:not(:active):not(:disabled),
+.primary:hover:not(:disabled):not(:focus-visible) {
   background: linear-gradient(105.01deg, #0154ac 17.25%, #1876db 93.21%);
 }
 
-.primary.warning:focus:not(:active):not(:disabled),
-.primary.warning:hover:not(:disabled):not(:focus) {
+.primary.warning:focus-visible:not(:active):not(:disabled),
+.primary.warning:hover:not(:disabled):not(:focus-visible) {
   background: linear-gradient(95.27deg, #611d18 4.76%, #943832 81.28%);
 }
 
-.secondary:hover:not(:disabled):not(:focus),
-.primary:hover:not(:disabled):not(:focus) {
+.secondary:hover:not(:disabled):not(:focus-visible),
+.primary:hover:not(:disabled):not(:focus-visible) {
   box-shadow:
     0 9px 12px 0 rgba(0, 0, 0, 0.2),
     0 19px 29px 0 rgba(0, 0, 0, 0.14),
     0 7px 36px 0 rgba(0, 0, 0, 0.12);
 }
 
-.primary:not(:disabled):focus:active,
-.secondary:not(:disabled):focus:active {
+.primary:not(:disabled):focus-visible:active,
+.secondary:not(:disabled):focus-visible:active {
   box-shadow: none;
 }
 </style>

--- a/src/components/NewButton/NewButton.vue
+++ b/src/components/NewButton/NewButton.vue
@@ -1,12 +1,13 @@
 <template>
   <button
     :class="[
-      'flex justify-center items-center rounded-lg tracking-[-0.04em] focus-visible:ring-4 focus-visible:outline-none',
+      'flex justify-center items-center rounded-lg tracking-[-0.04em] focus-visible:ring-4 focus:outline-none',
       { 'font-bold': primary || secondary },
       { 'px-8 text-[20px] h-[48px]': regular },
       { 'px-6 text-[14px] h-[32px]': small },
-      { 'p-0 text-base text-primary-500 underline disabled:text-gray-500': link },
-      { 'p-0 text-base disabled:text-gray-500': none },
+      { 'px-0 h-full text-base': link || none },
+      { 'text-primary-500 underline disabled:text-gray-500': link },
+      { 'disabled:text-gray-500': none },
       { 'cursor-not-allowed': disabled },
       { 'focus-visible:ring-primary-100': !warning },
       { 'focus-visible:ring-coral-700': warning },
@@ -77,30 +78,26 @@ export default {
 </script>
 
 <style scoped lang="scss">
-.textTwenty {
-  font-size: 20px;
-}
-
-.primary:focus-visible:not(:active):not(:disabled),
-.primary:hover:not(:disabled):not(:focus-visible) {
+.primary:focus:not(:active):not(:disabled),
+.primary:hover:not(:disabled):not(:focus) {
   background: linear-gradient(105.01deg, #0154ac 17.25%, #1876db 93.21%);
 }
 
-.primary.warning:focus-visible:not(:active):not(:disabled),
-.primary.warning:hover:not(:disabled):not(:focus-visible) {
+.primary.warning:focus:not(:active):not(:disabled),
+.primary.warning:hover:not(:disabled):not(:focus) {
   background: linear-gradient(95.27deg, #611d18 4.76%, #943832 81.28%);
 }
 
-.secondary:hover:not(:disabled):not(:focus-visible),
-.primary:hover:not(:disabled):not(:focus-visible) {
+.secondary:hover:not(:disabled):not(:focus),
+.primary:hover:not(:disabled):not(:focus) {
   box-shadow:
     0 9px 12px 0 rgba(0, 0, 0, 0.2),
     0 19px 29px 0 rgba(0, 0, 0, 0.14),
     0 7px 36px 0 rgba(0, 0, 0, 0.12);
 }
 
-.primary:not(:disabled):focus-visible:active,
-.secondary:not(:disabled):focus-visible:active {
+.primary:not(:disabled):focus:active,
+.secondary:not(:disabled):focus:active {
   box-shadow: none;
 }
 </style>


### PR DESCRIPTION
## Description

Some styling changes following [discussion on Slack](https://lob.slack.com/archives/C037J0X9PGD/p1650485832640789).

- fixed height (regular: 48px, small: 32px)
- letter-spacing -0.04em
- change focus ring to be visible only for keyboard navigation/tabbing
- add `small` prop for small size button (text 14px)

## [Demo link here](https://deploy-preview-240--elegant-yalow-f821c3.netlify.app/?path=/story/components-newbutton--default) 

**regular / small**
<img width="250" alt="Screen Shot 2022-05-03 at 1 06 02 PM" src="https://user-images.githubusercontent.com/50080618/166557273-75bac99e-98fc-4320-9f7b-eb00fc09d278.png">. <img width="250" alt="Screen Shot 2022-05-03 at 1 06 06 PM" src="https://user-images.githubusercontent.com/50080618/166557277-8bc9c99c-a294-4f03-ad4f-1b3a38ba489a.png">

