### PR TITLE
fix: Verticalstepper fix font-bold for active.& hover & change outline to ring

### DIFF
--- a/src/components/StepperVertical/StepperVerticalItem.vue
+++ b/src/components/StepperVertical/StepperVerticalItem.vue
@@ -1,10 +1,10 @@
 <template>
   <div
     :class="['whitespace-nowrap cursor-pointer text-lg font-thin',
-             'customHoverTrigger focus-visible:font-bold',
+             'rounded-r-full customHoverTrigger focus:font-bold',
              { 'text-primary-500 focus-visible:outline-primary-500': !darkMode },
-             { 'text-white focus-visible:outline-white': darkMode },
-             { 'font-bold': active }]"
+             { 'text-white focus-visible:outline-white': darkMode }
+    ]"
     tabindex="0"
     @keydown.enter="selectStep"
   >
@@ -16,7 +16,7 @@
                { 'text-white': active && !darkMode },
                { 'text-primary-500': active && darkMode },
                { 'w-20 customHoverW': !active },
-               { 'w-full delay-100': active }]"
+               { 'w-full delay-100 font-bold': active }]"
     >
       <span
         :class="['ml-14 inline-block w-4',

--- a/src/components/StepperVertical/StepperVerticalItem.vue
+++ b/src/components/StepperVertical/StepperVerticalItem.vue
@@ -1,9 +1,9 @@
 <template>
   <div
-    :class="['whitespace-nowrap cursor-pointer text-lg font-thin',
-             'rounded-r-full customHoverTrigger focus:font-bold',
-             { 'text-primary-500 focus-visible:outline-primary-500': !darkMode },
-             { 'text-white focus-visible:outline-white': darkMode }
+    :class="['whitespace-nowrap cursor-pointer text-lg font-thin rounded-r-full',
+             'customHoverTrigger focus:font-bold focus:outline-none focus-visible:ring-2',
+             { 'text-primary-500 focus-visible:ring-primary-500': !darkMode },
+             { 'text-white focus-visible:ring-white': darkMode }
     ]"
     tabindex="0"
     @keydown.enter="selectStep"


### PR DESCRIPTION
the boldness of an active/focused item seems to have been lost during the previous PR changes / although it still showed on the preview - not sure what happened

- this puts the bold back for active & hover (1 div closer for better specificity)
- & also changes the outline to ring for the keyboard focus (not sure why I'd picked outline - it doesn't do border-radius)