### PR TITLE
Fix alert style nits

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.188",
+  "version": "0.0.189",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/Alert/Alert.mdx
+++ b/src/components/Alert/Alert.mdx
@@ -50,7 +50,7 @@ Example of using this component with a link
 <alert>
   <template v-slot:default="{linkColor}">
     {{ content }}
-    <span :class="linkColor">
+    <span :class="linkColor" class="inline-flex">
       <LobLink bold inherit-text-color>{{ link }}</LobLink>.
     </span>
   </template>

--- a/src/components/Alert/Alert.stories.js
+++ b/src/components/Alert/Alert.stories.js
@@ -41,7 +41,7 @@ const Template = (args, { argTypes }) => ({
       <template v-slot:default="{linkColor}">
         {{ args.content }}
         <span :class="linkColor">
-          <LobLink bold inherit-text-color class="ml-1">{{ args.link }}</LobLink>.
+          <LobLink bold inherit-text-color class="inline-flex">{{ args.link }}</LobLink>.
         </span>
       </template>
     </alert>

--- a/src/components/Alert/Alert.vue
+++ b/src/components/Alert/Alert.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :class="['w-full border-l-4 p-4.5 rounded-r-lg flex justify-start align-center font-light',
+    :class="['w-full border-l-4 p-4.5 rounded-r-lg flex justify-start items-center font-light',
              { 'bg-turquoise-100 border-turquoise-500': info },
              { 'bg-mint-100 border-success': success },
              { 'bg-lemon-100 border-warning': warning },
@@ -9,9 +9,11 @@
   >
     <component
       :is="icon"
-      class="mr-4"
+      class="mr-4 flex-shrink-0"
     />
-    <slot :link-color="linkColor" />
+    <div class="block">
+      <slot :link-color="linkColor" />
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
fix for a couple things we didn't catch: 
- the Alert div should have items-center class.
- the icon needs a no-shrink because it sits in flex.
- the text & link need a block wrapper so that the link can sit as inline-flex.

**before:**
<img width="400" alt="Screen Shot 2022-05-09 at 12 03 50 PM" src="https://user-images.githubusercontent.com/50080618/167480325-140766ef-0d51-4da4-9543-82c7002df20b.png">
**after:**
<img width="400" alt="Screen Shot 2022-05-09 at 12 04 07 PM" src="https://user-images.githubusercontent.com/50080618/167480319-2c3ef693-b514-47a4-a51f-3e24a3233c83.png">

