### PR TITLE
fix: give Icons currentColor instead of fixed color

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.190",
+  "version": "0.0.191",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.190",
+  "version": "0.0.191",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/Alert/Alert.vue
+++ b/src/components/Alert/Alert.vue
@@ -10,6 +10,11 @@
     <component
       :is="icon"
       class="mr-4 h-6 w-6 flex-shrink-0"
+      :class="[{ 'text-gray-500': success },
+               { 'text-turquoise-500': info },
+               { 'text-warning': warning },
+               { 'text-coral-700': error }
+      ]"
     />
     <div class="block">
       <slot :link-color="linkColor" />

--- a/src/components/Alert/Alert.vue
+++ b/src/components/Alert/Alert.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :class="['w-full border-l-4 p-4.5 rounded-r-lg flex justify-start items-center font-light',
+    :class="['w-full border-l-4 p-4.5 rounded-r-lg flex justify-start items-center font-light text-sm',
              { 'bg-turquoise-100 border-turquoise-500': info },
              { 'bg-mint-100 border-success': success },
              { 'bg-lemon-100 border-warning': warning },

--- a/src/components/Icons/Checkmark.vue
+++ b/src/components/Icons/Checkmark.vue
@@ -1,20 +1,18 @@
 <template>
   <svg
-    width="24"
-    height="24"
     viewBox="0 0 24 24"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
       d="M12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21Z"
-      stroke="#416581"
+      stroke="currentColor"
       stroke-linecap="round"
       stroke-linejoin="round"
     />
     <path
       d="M8.14285 12L10.7143 14.5714L15.8571 9.42856"
-      stroke="#416581"
+      stroke="currentColor"
       stroke-linecap="round"
       stroke-linejoin="round"
     />

--- a/src/components/Icons/Error.vue
+++ b/src/components/Icons/Error.vue
@@ -1,7 +1,5 @@
 <template>
   <svg
-    width="24"
-    height="24"
     viewBox="0 0 24 24"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
@@ -10,13 +8,13 @@
       cx="12"
       cy="12"
       r="9"
-      stroke="#DB807A"
+      stroke="currentColor"
       stroke-linecap="round"
       stroke-linejoin="round"
     />
     <path
       d="M12 8V12"
-      stroke="#DB807A"
+      stroke="currentColor"
       stroke-width="1.5"
       stroke-linecap="round"
       stroke-linejoin="round"

--- a/src/components/Icons/Info.vue
+++ b/src/components/Icons/Info.vue
@@ -1,7 +1,5 @@
 <template>
   <svg
-    width="24"
-    height="24"
     viewBox="0 0 24 24"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
@@ -10,11 +8,11 @@
       cx="12"
       cy="12"
       r="8.5"
-      stroke="#57A1B9"
+      stroke="currentColor"
     />
     <path
       d="M12.302 7C11.574 7 11 7.546 11 8.274C11 9.002 11.574 9.548 12.302 9.548C13.03 9.548 13.618 9.002 13.618 8.274C13.618 7.546 13.03 7 12.302 7ZM13.45 17.416V11.276L11.168 12.276V17.416H13.45Z"
-      fill="#57A1B9"
+      fill="currentColor"
     />
   </svg>
 </template>

--- a/src/components/Icons/Warning.vue
+++ b/src/components/Icons/Warning.vue
@@ -1,7 +1,5 @@
 <template>
   <svg
-    width="24"
-    height="24"
     viewBox="0 0 24 24"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
@@ -10,11 +8,11 @@
       cx="12"
       cy="12"
       r="8.5"
-      stroke="#F5AE5B"
+      stroke="currentColor"
     />
     <path
       d="M12.302 7C11.574 7 11 7.546 11 8.274C11 9.002 11.574 9.548 12.302 9.548C13.03 9.548 13.618 9.002 13.618 8.274C13.618 7.546 13.03 7 12.302 7ZM13.45 17.416V11.276L11.168 12.276V17.416H13.45Z"
-      fill="#F5AE5B"
+      fill="currentColor"
     />
   </svg>
 </template>


### PR DESCRIPTION
see [Alerts figma here](https://www.figma.com/file/h2T4pIQzH1M17LFGXMbJ4u/Design-System-(Blendr)-Hand-Off?node-id=145%3A1288)

The Icons: Checkmark Warning Info and Error have slightly changed.
Copying the svg from figma gives you the fixed color that is in use in that design. But we use Icons with other colors too so we should be allowing the svg to read currentColor instead of a fixed color. (passed in as ie. text-{color})
This commit puts currentColor on the stroke of these svgs.

To confirm it works look at the Alert icons and compare with the Info icon used in the tooltip of textinput in storybook.