### PR TITLE
final nits on Alert, font and padding changes as advised by Adam

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.193",
+  "version": "0.0.194",
   "lockfileVersion": 1,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.193",
+  "version": "0.0.194",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/Alert/Alert.vue
+++ b/src/components/Alert/Alert.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :class="['w-full border-l-4 p-4.5 rounded-r-lg flex justify-start items-center font-light text-sm',
+    :class="['w-full border-l-4 py-3 px-4 rounded-r-lg flex justify-start items-start text-sm',
              { 'bg-turquoise-100 border-turquoise-500': info },
              { 'bg-mint-100 border-success': success },
              { 'bg-lemon-100 border-warning': warning },
@@ -9,14 +9,14 @@
   >
     <component
       :is="icon"
-      class="mr-4 h-6 w-6 flex-shrink-0"
+      class="h-6 w-6 flex-shrink-0"
       :class="[{ 'text-gray-500': success },
                { 'text-turquoise-500': info },
                { 'text-warning': warning },
                { 'text-coral-700': error }
       ]"
     />
-    <div class="block">
+    <div class="block px-4">
       <slot :link-color="linkColor" />
     </div>
   </div>

--- a/src/components/Switch/SwitchItem.vue
+++ b/src/components/Switch/SwitchItem.vue
@@ -2,7 +2,7 @@
   <div
     :class="[
       'rounded-sm flex bg-white text-primary-500 font-thin',
-      { '!bg-primary-500 !text-white checked font-semibold': checked },
+      { '!bg-primary-500 !text-white checked !font-semibold': checked },
       { '!bg-white-300': disabled }
     ]"
   >


### PR DESCRIPTION
- The text should be regular and not light. (we should also be able to have bold text in it as well)
- The padding above and below the text/icon block should be 12.
- The right / left to the dark line padding on the light background box should be 16, think it is 18.

requested changes implemented, new screenshots:

<img width="600" alt="Screen Shot 2022-05-12 at 12 38 57 PM" src="https://user-images.githubusercontent.com/50080618/168155041-6d1ce46e-6430-4a9f-b83f-65d7904afe79.png">


<img width="600" alt="Screen Shot 2022-05-12 at 12 34 07 PM" src="https://user-images.githubusercontent.com/50080618/168154451-4e34f661-2234-4aa2-a048-9f59d39550bb.png">
<img width="400" alt="Screen Shot 2022-05-12 at 12 34 30 PM" src="https://user-images.githubusercontent.com/50080618/168154457-4e80ebdb-9748-483b-844b-5be669bbd7a4.png">

**[Alert review thread on Slack](https://lob.slack.com/archives/C037J0X9PGD/p1651066123161959)** for ref