### PR TITLE
NewLink nit: set inheritAttrs to false at component level this will stop attrs duplicating

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.194",
+  "version": "0.0.196",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "0.0.195",
+      "version": "0.0.196",
       "dependencies": {
         "date-fns": "^2.23.0",
         "mitt": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.195",
+  "version": "0.0.196",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/NewLink/NewLink.vue
+++ b/src/components/NewLink/NewLink.vue
@@ -48,6 +48,7 @@ import { ChevronRight } from '@/components/Icons';
 export default {
   name: 'NewLink',
   components: { ChevronRight },
+  inheritAttrs: false,
   props: {
     variant: {
       type: String,


### PR DESCRIPTION
Setting `inheritAttrs` to false at component level this will stop the role="link" and data-testIds etc from duplicating in tests

we are using v-bind to pass the attrs onto the inner element which is the actual link


**[Vue docs on disabling attribute inheritance](https://vuejs.org/guide/components/attrs.html#disabling-attribute-inheritance)**