### PR TITLE
fix: change newlink wrapper to be inline-block so it sits better in text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.196",
+  "version": "0.0.197",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "0.0.196",
+      "version": "0.0.197",
       "dependencies": {
         "date-fns": "^2.23.0",
         "mitt": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "0.0.196",
+  "version": "0.0.197",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/NewLink/NewLink.vue
+++ b/src/components/NewLink/NewLink.vue
@@ -1,5 +1,8 @@
 <template>
-  <div :class="{ 'cursor-not-allowed': disabled, 'cursor-pointer': !disabled }">
+  <div
+    :class="['inline-block',
+             { 'cursor-not-allowed': disabled, 'cursor-pointer': !disabled }]"
+  >
     <component
       :is="tag"
       :[linkProp]="to"

--- a/src/components/Subnavigation/SubnavigationItem.vue
+++ b/src/components/Subnavigation/SubnavigationItem.vue
@@ -1,10 +1,12 @@
 <template>
   <li
     class="list-none mr-12 whitespace-nowrap"
+    :class="['relative pb-4', { 'lob-active-border': active }]"
   >
     <NewLink
       :to="to"
-      :class="['relative pb-4 no-underline text-black font-light', { 'lob-active-border font-normal': active }]"
+      :underline="false"
+      :class="['pb-4 text-black font-light', { 'font-normal': active }]"
     >
       {{ title }}
     </NewLink>

--- a/src/components/Subnavigation/__tests__/SubnavigationItem.spec.js
+++ b/src/components/Subnavigation/__tests__/SubnavigationItem.spec.js
@@ -40,7 +40,7 @@ describe('SubnavigationItem', () => {
     await router.isReady();
 
     const navItem = queryByRole('link', { name: 'Account' });
-    expect(navItem).toHaveClass('lob-active-border');
+    expect(navItem).toHaveClass('font-normal');
   });
 
 });


### PR DESCRIPTION
One more little nit on the NewLink. I noticed the [Alert got wonky](https://ui-components.lob.com/?path=/story/components-alert--primary) because the link was a block. 
This makes the NewLink wrapper to be `inline-block` so that it sits nicely inside text.

[see Alert in preview](https://deploy-preview-257--elegant-yalow-f821c3.netlify.app/?path=/story/components-alert--primary)

[see NewLink in preview](https://deploy-preview-257--elegant-yalow-f821c3.netlify.app/?path=/story/components-newlink--regular-link)

adds fix for Subnavigation that was broken because of NewLink attr inheritance
