### PR TITLE
Dang 1254/upload file with new secondary button style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Features
 
 - Update FileUpload component to the new button style.
+
+### Breaking changes
+
 - The `size` prop on FileUpload is now a Boolean prop `small`
 
 ## 1.0.0-beta.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,119 +1,166 @@
 # CHANGELOG
 
+## 1.0.0-beta.6
+
+### Features
+
+- Update FileUpload component to the new button style.
+- The `size` prop on FileUpload is now a Boolean prop `small`
+
 ## 1.0.0-beta.5
+
 ### Accessibility improvement
-* Change the @hover text color to be primary-900 on NewLink & NewButton styled as a link so that the color difference is more obvious (from the default primary-500 text color)
+
+- Change the @hover text color to be primary-900 on NewLink & NewButton styled as a link so that the color difference is more obvious (from the default primary-500 text color)
 
 ## 1.0.0-beta.4
+
 ### Bug Fixes
-* Styling adjustments to the NewLink and MainNavigationChildItem components to allow the MainNavigation to display focus rings correctly
+
+- Styling adjustments to the NewLink and MainNavigationChildItem components to allow the MainNavigation to display focus rings correctly
 
 ## 1.0.0-beta.3
+
 ### Features
-* Updated the RadioGroup component to work with both RadioButton and MegaButton components as children
+
+- Updated the RadioGroup component to work with both RadioButton and MegaButton components as children
 
 ### Bug Fixes
-* Added the MegaButton to the exported components (prior to this version the MegaButton would not have been accessible)
+
+- Added the MegaButton to the exported components (prior to this version the MegaButton would not have been accessible)
 
 ## 1.0.0-beta.2
+
 ### Bug Fixes
-* Styling adjustments to the MainNavigation component concerning the focus ring
+
+- Styling adjustments to the MainNavigation component concerning the focus ring
 
 ## 1.0.0-beta.1
+
 ### Features
-* Restyle of [Dropdown component](./src/components/Dropdown/Dropdown.mdx)
+
+- Restyle of [Dropdown component](./src/components/Dropdown/Dropdown.mdx)
 
 ### Breaking changes
-* list-height prop previously expected a value from the available list of [https://tailwindcss.com/docs/height](Tailwind CSS heights).
-Now the value expected should be an actual number value with units (i.e. '20rem', '256px').
-* any `class` prop that was previous defined on a `Dropdown` component needs to be moved to an enclosing `<div></div>` as the `Dropdown` no
-longer has a built-in wrapper with which to pass the `class` prop down to.  You need to provide your own wrapper now.
+
+- list-height prop previously expected a value from the available list of [https://tailwindcss.com/docs/height](Tailwind CSS heights).
+  Now the value expected should be an actual number value with units (i.e. '20rem', '256px').
+- any `class` prop that was previous defined on a `Dropdown` component needs to be moved to an enclosing `<div></div>` as the `Dropdown` no
+  longer has a built-in wrapper with which to pass the `class` prop down to. You need to provide your own wrapper now.
 
 ## 0.0.197
+
 ### Bug Fixes
-* Changed NewLink wrapper to be inline-block so it sits better in text
-* Subnavigation after NewLink changes broke styling
+
+- Changed NewLink wrapper to be inline-block so it sits better in text
+- Subnavigation after NewLink changes broke styling
 
 ## 0.0.196
+
 ### Bug Fixes
-* Set inheritAttrs to false at component level this will stop the role="link" and data-testIds etc from duplicating in tests
+
+- Set inheritAttrs to false at component level this will stop the role="link" and data-testIds etc from duplicating in tests
 
 ## 0.0.195
+
 ### Features
-* Added new [NewLink component](./src/components/NewLink/NewLink.mdx) (with the new button styles primary & secondary)
-* Added images support to the Megabutton component
-  * New prop `imageSource` added allowing for the display of an image in a Megabutton
+
+- Added new [NewLink component](./src/components/NewLink/NewLink.mdx) (with the new button styles primary & secondary)
+- Added images support to the Megabutton component
+  - New prop `imageSource` added allowing for the display of an image in a Megabutton
 
 ### Noteworthy Changes
-* NewLink is being added to provide a backwards compatible migration path to updating the LobLink.
-LobLink instances can be updated to use NewLink at this time.  At some point in the near future we will be renaming NewLink to LobLink.
-If your application uses LobLink you can choose to migrate to NewLink now and change its name later, or wait until NewLink is renamed to LobLink
-which may require some props changes at that time.
-* NewLink `variant` prop values are now [`link`, `primary-button`, `secondary-button`]
-* The `size` prop on LobLink is now a Boolean prop `small` on NewLink
+
+- NewLink is being added to provide a backwards compatible migration path to updating the LobLink.
+  LobLink instances can be updated to use NewLink at this time. At some point in the near future we will be renaming NewLink to LobLink.
+  If your application uses LobLink you can choose to migrate to NewLink now and change its name later, or wait until NewLink is renamed to LobLink
+  which may require some props changes at that time.
+- NewLink `variant` prop values are now [`link`, `primary-button`, `secondary-button`]
+- The `size` prop on LobLink is now a Boolean prop `small` on NewLink
 
 ## 0.0.194
+
 ### Bug Fixes
-* Styling adjustments to Alert (font and padding changes)
+
+- Styling adjustments to Alert (font and padding changes)
 
 ## 0.0.193
+
 ### Bug Fixes
-* Revert changes made in version 0.0.192
+
+- Revert changes made in version 0.0.192
 
 ## 0.0.192
+
 ### Features
-* Transfer Primary and Secondary Button styles onto Link
-* Added new [Megabutton component](./src/components/MegaButton/MegaButton.mdx)
-* Added small text support to the Megabutton:
-  * New prop `text` added allowing for the display of smaller text under the label in a Megabutton
+
+- Transfer Primary and Secondary Button styles onto Link
+- Added new [Megabutton component](./src/components/MegaButton/MegaButton.mdx)
+- Added small text support to the Megabutton:
+  - New prop `text` added allowing for the display of smaller text under the label in a Megabutton
 
 ## 0.0.191
+
 ### Bug Fixes
-* Gave Icons `currentColor` instead of fixed color
-* Added text size 14 to the Alert
+
+- Gave Icons `currentColor` instead of fixed color
+- Added text size 14 to the Alert
 
 ## 0.0.190
+
 ### Bug Fixes
-* Temp fix in Link so that we can merge Alerts in dashboard-vue
-* Fix Icons that are used in Alert
-* Added !important for the MainNavigation text color
+
+- Temp fix in Link so that we can merge Alerts in dashboard-vue
+- Fix Icons that are used in Alert
+- Added !important for the MainNavigation text color
 
 ## 0.0.189
+
 ### Bug Fixes
-* Small styling adjustments to Alert to keep text and link together and Icon not to shrink
+
+- Small styling adjustments to Alert to keep text and link together and Icon not to shrink
 
 ## 0.0.188
+
 ### Features
-* Restyle of [Alert component](./src/components/Alert/Alert.mdx)
-* Updated Icons (Checkmark, Error, Info, Warning) used by restyled Alert component
-* Added new props to Link component (to support the use of Links inside Alerts):
-  * New prop `bold`, when `true` will display the Link with a bold font weight
-  * New prop `inheritTextColor`, when `true` will display the Link in the color as defined by its parent
+
+- Restyle of [Alert component](./src/components/Alert/Alert.mdx)
+- Updated Icons (Checkmark, Error, Info, Warning) used by restyled Alert component
+- Added new props to Link component (to support the use of Links inside Alerts):
+  - New prop `bold`, when `true` will display the Link with a bold font weight
+  - New prop `inheritTextColor`, when `true` will display the Link in the color as defined by its parent
 
 ### Breaking/Noteworthy Changes
-* Using a Link inside of an Alert component requires a specific approach to style the Link with the correct color.
-See the section `Example of using this component with a link` in the [Alert documentation](./src/components/Alert/Alert.mdx) for details.
-* Previously when using an Icon inside an Alert, the Icon had to be provided within a `<slot>`, now the Icon is built into the Alert and is defined
-by the `variant` prop value.
+
+- Using a Link inside of an Alert component requires a specific approach to style the Link with the correct color.
+  See the section `Example of using this component with a link` in the [Alert documentation](./src/components/Alert/Alert.mdx) for details.
+- Previously when using an Icon inside an Alert, the Icon had to be provided within a `<slot>`, now the Icon is built into the Alert and is defined
+  by the `variant` prop value.
 
 ## 0.0.187
+
 ### Features
-* Added new prop to NewButton:
-  * new prop `small`, when `true` will display a smaller version of the button
+
+- Added new prop to NewButton:
+  - new prop `small`, when `true` will display a smaller version of the button
 
 ### Bug Fixes
-* Styling adjustments to NewButton component
-* Styling adjustments to the VerticalStepper component
+
+- Styling adjustments to NewButton component
+- Styling adjustments to the VerticalStepper component
 
 ## 0.0.186
+
 ### Features
-* Added new [NewButton component](./src/components/NewButton/NewButton.mdx)
-* Added new [StepperVertical component](./src/components/StepperVertical/StepperVertical.mdx)
+
+- Added new [NewButton component](./src/components/NewButton/NewButton.mdx)
+- Added new [StepperVertical component](./src/components/StepperVertical/StepperVertical.mdx)
 
 ### Noteworthy Changes
-* NewButton is being added to provide a backwards compatible migration path to updating the LobButton.
-LobButton instances can be updated to use NewButton at this time.  At some point in the near future we will be renaming NewButton to LobButton.
-If your application uses LobButton you can choose to migrate to NewButton now and change its name later, or wait until NewButton is renamed to LobButton
-which may require some props changes at that time.
-* NewButton `variant` prop values are now [`primary`, `secondary`, `link`, `none`] (if something was `tertiary` it should now be `secondary`)
-* The `size` prop on LobButton is now a Boolean prop `small` on NewButton
+
+- NewButton is being added to provide a backwards compatible migration path to updating the LobButton.
+  LobButton instances can be updated to use NewButton at this time. At some point in the near future we will be renaming NewButton to LobButton.
+  If your application uses LobButton you can choose to migrate to NewButton now and change its name later, or wait until NewButton is renamed to LobButton
+  which may require some props changes at that time.
+- NewButton `variant` prop values are now [`primary`, `secondary`, `link`, `none`] (if something was `tertiary` it should now be `secondary`)
+- The `size` prop on LobButton is now a Boolean prop `small` on NewButton

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "1.0.0-beta.5",
+      "version": "1.0.0-beta.6",
       "dependencies": {
         "date-fns": "^2.23.0",
         "mitt": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/FileUpload/FileUpload.stories.js
+++ b/src/components/FileUpload/FileUpload.stories.js
@@ -10,10 +10,9 @@ export default {
     }
   },
   argTypes: {
-    size: {
-      options: ['default', 'small', 'large'],
+    small: {
       control: {
-        type: 'select'
+        type: 'boolean'
       }
     }
   }

--- a/src/components/FileUpload/FileUpload.vue
+++ b/src/components/FileUpload/FileUpload.vue
@@ -2,17 +2,17 @@
   <label
     :for="id"
     v-bind="$attrs"
-    class="text-center"
   >
     <span
       role="button"
       aria-controls="filename"
       tabindex="0"
       :class="[
-        'button bg-white-200 border border-primary-500 text-primary-500 active:text-primary-700 active:border-primary-700 disabled:border-gray-100 rounded disabled:text-gray-500 focus:outline-none focus:ring-2 focus:ring-primary-100 focus:border-transparent cursor-pointer inline-block truncate w-full',
-        { 'px-6 py-3.5': defaultSize },
-        { 'px-3 py-2': small },
-        { 'px-6 py-4.5': large }
+        { 'px-8 text-[1.25rem] h-[48px]': regular },
+        { 'px-6 text-sm h-[32px]': small },
+        'flex justify-center items-center rounded-lg border border-primary-500',
+        'font-bold tracking-[-0.04em] bg-white text-primary-500 secondary',
+        'active:border-black active:text-black focus-visible:ring-primary-100 focus-visible:ring-4 focus:outline-none'
       ]"
       @keydown.enter="onKeydown"
       @keydown.space="onKeydown"
@@ -48,12 +48,9 @@ export default {
       type: String,
       required: true
     },
-    size: {
-      type: String,
-      default: 'default',
-      validator: function (value) {
-        return ['default', 'small', 'large'].includes(value);
-      }
+    small: {
+      type: Boolean,
+      default: false
     }
   },
   emits: ['fileUpload'],
@@ -63,14 +60,8 @@ export default {
     };
   },
   computed: {
-    defaultSize () {
-      return this.size === 'default';
-    },
-    small () {
-      return this.size === 'small';
-    },
-    large () {
-      return this.size === 'large';
+    regular () {
+      return !this.small;
     }
   },
   methods: {
@@ -92,8 +83,15 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped>
-.button:hover:not(:disabled):not(:focus) {
-  box-shadow: 0 0 10px rgba(65, 101, 129, 0.2);
+<style scoped lang="scss">
+.secondary:hover:not(:disabled):not(:focus) {
+  box-shadow:
+    0 9px 12px 0 rgba(0, 0, 0, 0.2),
+    0 19px 29px 0 rgba(0, 0, 0, 0.14),
+    0 7px 36px 0 rgba(0, 0, 0, 0.12);
+}
+
+.secondary:not(:disabled):focus:active {
+  box-shadow: none;
 }
 </style>

--- a/src/components/FileUpload/FileUpload.vue
+++ b/src/components/FileUpload/FileUpload.vue
@@ -1,8 +1,5 @@
 <template>
-  <label
-    :for="id"
-    v-bind="$attrs"
-  >
+  <label :for="id">
     <span
       role="button"
       aria-controls="filename"
@@ -84,14 +81,14 @@ export default {
 </script>
 
 <style scoped lang="scss">
-.secondary:hover:not(:disabled):not(:focus) {
+.secondary:hover:not(:focus) {
   box-shadow:
     0 9px 12px 0 rgba(0, 0, 0, 0.2),
     0 19px 29px 0 rgba(0, 0, 0, 0.14),
     0 7px 36px 0 rgba(0, 0, 0, 0.12);
 }
 
-.secondary:not(:disabled):focus:active {
+.secondary:focus:active {
   box-shadow: none;
 }
 </style>


### PR DESCRIPTION
## JIRA

[dang-1254](https://lobsters.atlassian.net/browse/DANG-1254)


## Description

we'd missed this because it is not a button but an input component styled as one

changes:
- new button style, secondary only
- prop 'size' is now 'small' as we only use regular and small (no large is in use, and there is not a large new button style)

<img width="331" alt="Screen Shot 2022-05-25 at 10 09 29 AM" src="https://user-images.githubusercontent.com/50080618/170282474-7ac456eb-1ebb-4b82-a22f-71fd5d622615.png"> <img width="331" alt="Screen Shot 2022-05-25 at 10 09 32 AM" src="https://user-images.githubusercontent.com/50080618/170282472-cc87781d-40a0-41d7-b38a-fb005a15ba55.png"> 

on the dashboard it looks like this:
<img width="407" alt="Screen Shot 2022-05-25 at 10 28 12 AM" src="https://user-images.githubusercontent.com/50080618/170286651-8ea8252a-ab49-4c0e-a51c-5a727ebee224.png">

