### PR TITLE
fix colors story as we put them back in theme

### DIFF
--- a/src/theme/colors/Colors.vue
+++ b/src/theme/colors/Colors.vue
@@ -34,7 +34,7 @@
 import { config } from 'tailwind-plugin-lob';
 
 const { theme } = config;
-const { colors } = theme.extend;
+const { colors } = theme;
 
 export default {
   name: 'Theme',
@@ -43,7 +43,7 @@ export default {
       return colors;
     },
     theme () {
-      return theme.extend;
+      return theme;
     }
   }
 };


### PR DESCRIPTION
current Colors is [a little bit broken ](https://ui-components.lob.com/?path=/story/theme-dev-only-colors--primary)

<img width="500" alt="Screen Shot 2022-05-26 at 8 04 08 AM" src="https://user-images.githubusercontent.com/50080618/170484618-a4aac5c8-9a92-44c1-a0bd-f9d8dc51b837.png">

it is because we put the colors back into theme and out of extend

this fixes it