### PR TITLE
Update dropdown size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.9",
+  "version": "1.0.0-beta.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "1.0.0-beta.9",
+      "version": "1.0.0-beta.10",
       "dependencies": {
         "date-fns": "^2.23.0",
         "mitt": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.9",
+  "version": "1.0.0-beta.10",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/Dropdown/Dropdown.vue
+++ b/src/components/Dropdown/Dropdown.vue
@@ -29,8 +29,8 @@
       :aria-required="required"
       :aria-disabled="disabled"
       :class="[
-        'cursor-default bg-white border rounded-lg border-gray-100 focus:outline-none focus:shadow hover:shadow font-light text-gray-900 flex items-center',
-        {'text-sm py-2 px-2.5': small},
+        'cursor-default bg-white border rounded-lg border-gray-100 focus:outline-none focus:shadow hover:shadow font-light text-gray-900 flex align-center items-center',
+        {'h-8 text-sm py-2 px-2.5': small},
         {'h-12 py-2.5 px-4': default_},
         {'!border-error': error},
         {'!bg-white-100 pointer-events-none': disabled},
@@ -57,18 +57,14 @@
       <chevron-down
         v-if="!open"
         :class="[
-          'w-4 h-4 absolute right-2 text-gray-100',
-          {'top-3': small},
-          {'top-4': default_}
+          'w-4 h-4 absolute right-2 text-gray-100'
         ]"
         data-testid="chevron-down"
       />
       <chevron-up
         v-else
         :class="[
-          'w-4 h-4 absolute right-2 text-gray-100',
-          {'top-3': small},
-          {'top-4': default_}
+          'w-4 h-4 absolute right-2 text-gray-100'
         ]"
         data-testid="chevron-up"
       />

--- a/src/components/Dropdown/DropdownItem.vue
+++ b/src/components/Dropdown/DropdownItem.vue
@@ -3,9 +3,9 @@
     :id="id"
     ref="option"
     :class="[
-      'border-l-4 border-l-transparent truncate',
-      {'text-sm py-2 px-2.5': small},
-      {'py-2.5 px-4': default_},
+      'border-l-4 border-l-transparent truncate flex items-center',
+      {'text-sm h-7 px-2.5': small},
+      {'h-10 px-4': default_},
       {'font-light cursor-default': !option.disabled},
       {'bg-white-300 text-primary-500 font-bold !border-l-primary-500': active && !option.disabled && !selected},
       {'text-gray-100 cursor-not-allowed': option.disabled},


### PR DESCRIPTION
## JIRA

*[https://www.figma.com/file/h2T4pIQzH1M17LFGXMbJ4u/Design-System-(Blendr)-Hand-Off?node-id=994%3A9675]( https://www.figma.com/file/h2T4pIQzH1M17LFGXMbJ4u/Design-System-(Blendr)-Hand-Off?node-id=994%3A9675)

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

* Small dropdowns should be 32 px - this was not in the original dropdown design, but showed up on the text input design.  I also updated the height of dropdown item - It should be 40px - for default - small variant was not specified so I picked 28px.  Also made contents of dropdown align center via flex positioning so we could get rid of some of the absolute positioning.

<!--
## Screenshots
- before and after screenshots for features with visual changes
-->

<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
