### PR TITLE
DANG-1276/Update Textarea styles to match TextInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Style additions to the [Textarea component](./src/components/Textarea/Textarea.m
 
 - Width takes up the entire width of the container
 - Height set via Tailwind class
+- Changes made to match text input: larger corner rounding, focus & "has something in it" states
 
 ## 1.0.0-beta.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 Style additions to the [Textarea component](./src/components/Textarea/Textarea.mdx):
 
-- Width takes up the entire width of the container
+- Width takes up the entire width of the container (no longer need to pass in `input-class: "w-full"`)
 - Height set via Tailwind class
 - Changes made to match text input: larger corner rounding, focus & "has something in it" states
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 1.0.0-beta.14
+
+### Features
+
+Style additions to the [Textarea component](./src/components/Textarea/Textarea.mdx):
+
+- Width takes up the entire width of the container
+- Height set via Tailwind class
+
 ## 1.0.0-beta.13
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.13",
+  "version": "1.0.0-beta.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "1.0.0-beta.13",
+      "version": "1.0.0-beta.14",
       "dependencies": {
         "date-fns": "^2.23.0",
         "mitt": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.13",
+  "version": "1.0.0-beta.14",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/Textarea/Textarea.stories.js
+++ b/src/components/Textarea/Textarea.stories.js
@@ -22,11 +22,14 @@ export default {
   }
 };
 
+const textareaVModel = '';
+
 const Template = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: {  Textarea },
   setup: () => ({ args }),
-  template: '<Textarea v-bind="args"></Textarea>'
+  data: () => ({ textareaVModel }),
+  template: '<Textarea v-bind="args" v-model="textareaVModel"></Textarea>'
 });
 
 export const Primary = Template.bind({});
@@ -40,6 +43,7 @@ const WithTooltipTemplate = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { Textarea, Info, LobLabel, Tooltip },
   setup: () => ({ args }),
+  data: () => ({ textareaVModel }),
   template: `
     <LobLabel
       label="Cat nicknames"
@@ -57,7 +61,7 @@ const WithTooltipTemplate = (args, { argTypes }) => ({
         </Tooltip>
       </template>
     </LobLabel>
-    <Textarea v-bind="args" />
+    <Textarea v-bind="args" v-model="textareaVModel" />
   `
 });
 

--- a/src/components/Textarea/Textarea.vue
+++ b/src/components/Textarea/Textarea.vue
@@ -17,7 +17,7 @@
       :readonly="readonly"
       :placeholder="placeholder"
       :class="[
-        `bg-white text-gray-500 placeholder-gray-100 p-4 resize-none rounded border border-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-100 focus:border-transparent ${inputClass}`,
+        `bg-white text-gray-500 placeholder-gray-100 p-4 resize-none rounded border border-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-100 focus:border-transparent w-full h-40 ${inputClass}`,
         { 'border-error': error },
         { '!bg-white-300 cursor-not-allowed': disabled || readonly },
         { 'hover:shadow': !disabled && !readonly }
@@ -94,9 +94,3 @@ export default {
   }
 };
 </script>
-
-<style scoped lang="scss">
-textarea {
-  min-height: 10rem;
-}
-</style>

--- a/src/components/Textarea/Textarea.vue
+++ b/src/components/Textarea/Textarea.vue
@@ -17,10 +17,12 @@
       :readonly="readonly"
       :placeholder="placeholder"
       :class="[
-        `bg-white text-gray-500 placeholder-gray-100 p-4 resize-none rounded border border-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-100 focus:border-transparent w-full h-40 ${inputClass}`,
+        `bg-white text-gray-500 placeholder-gray-100 p-4 resize-none rounded-lg border border-gray-100 focus-within:outline-none w-full h-40 ${inputClass}`,
         { 'border-error': error },
         { '!bg-white-300 cursor-not-allowed': disabled || readonly },
-        { 'hover:shadow': !disabled && !readonly }
+        { 'hover:shadow focus-within:shadow focus-within:ring-1 focus-within:ring-primary-500 focus-within:border-primary-500': !disabled && !readonly },
+        { 'hover:shadow': !disabled && !readonly },
+        {'border-gray-500 focus-within:border-primary-500' : modelValue }
       ]"
       @input="onInput"
     />


### PR DESCRIPTION
## JIRA

* ~~N/A, found while working on reskin of campaigns name modal~~ ok I created a ticket for it, [https://lobsters.atlassian.net/browse/DANG-1276](https://lobsters.atlassian.net/browse/DANG-1276)

## Description

* Previously, you had to pass through an `inputClass` to make the width something else. To be consistent with the rest of many of our other components, added a `w-full` class.
* Also, we were setting the height via a style block, and that seems ... unnecessary. (Also causing issues when trying to override it.)
* Also changed the rounded corner radius and focus/"has something in it" states to match the text input, since they're now on top of one another in the campaigns name modal and it's very obvious that they were different. 😬 

## Screenshots

Before:

![Screen Shot 2022-06-02 at 2 46 14 PM](https://user-images.githubusercontent.com/20443660/171735130-00d2e975-9de6-42dc-879e-7486d1b6f3db.png)

After:

![Screen Shot 2022-06-02 at 3 14 40 PM](https://user-images.githubusercontent.com/20443660/171739543-458f4578-3dbe-46d8-9622-d5f9e5641c3f.png)

![Screen Shot 2022-06-02 at 3 14 45 PM](https://user-images.githubusercontent.com/20443660/171739555-ee2a5fa9-a4bd-4c34-a150-ef113014511b.png)
