### PR TITLE
DANG-1295 / add the new error color (update the tailwind plugin)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 1.0.0-beta.15
+
+### Features
+
+Update the Tailwind plugin to introduce the new `error` color #D75A5A.
+The previous `error` color is still available as `coral-900` (#943832).
+
 ## 1.0.0-beta.14
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "sass-loader": "^10.1.1",
         "stylelint": "^13.13.1",
         "stylelint-config-standard": "^22.0.0",
-        "tailwind-plugin-lob": "^0.0.32",
+        "tailwind-plugin-lob": "^0.0.35",
         "tailwindcss": "^3.0.24",
         "typescript": "~3.9.3",
         "vite": "^2.9.9",
@@ -20756,9 +20756,9 @@
       "dev": true
     },
     "node_modules/tailwind-plugin-lob": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/tailwind-plugin-lob/-/tailwind-plugin-lob-0.0.32.tgz",
-      "integrity": "sha512-0mEjW8Sdm8oWeBOTWufAWwc2lnVopcjRgvKChkRsLG6jrywvSAqKpLdEPXfvHQ65rsZmsa8SiXfbtduV3BTJKg==",
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/tailwind-plugin-lob/-/tailwind-plugin-lob-0.0.35.tgz",
+      "integrity": "sha512-diAEDNwIpzUjK6L2fM7ZV+OKLySvafklbAs/QJ1oO31MB1awusxq7WQs7Ln8z2k2QTRKqfpe7P4td0TKjb+Rqw==",
       "dev": true,
       "engines": {
         "node": ">=14.18.2"
@@ -39896,9 +39896,9 @@
       }
     },
     "tailwind-plugin-lob": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/tailwind-plugin-lob/-/tailwind-plugin-lob-0.0.32.tgz",
-      "integrity": "sha512-0mEjW8Sdm8oWeBOTWufAWwc2lnVopcjRgvKChkRsLG6jrywvSAqKpLdEPXfvHQ65rsZmsa8SiXfbtduV3BTJKg==",
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/tailwind-plugin-lob/-/tailwind-plugin-lob-0.0.35.tgz",
+      "integrity": "sha512-diAEDNwIpzUjK6L2fM7ZV+OKLySvafklbAs/QJ1oO31MB1awusxq7WQs7Ln8z2k2QTRKqfpe7P4td0TKjb+Rqw==",
       "dev": true
     },
     "tailwindcss": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "1.0.0-beta.14",
+      "version": "1.0.0-beta.16",
       "dependencies": {
         "date-fns": "^2.23.0",
         "mitt": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "sass-loader": "^10.1.1",
     "stylelint": "^13.13.1",
     "stylelint-config-standard": "^22.0.0",
-    "tailwind-plugin-lob": "^0.0.32",
+    "tailwind-plugin-lob": "^0.0.35",
     "tailwindcss": "^3.0.24",
     "typescript": "~3.9.3",
     "vite": "^2.9.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.16",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/Badge/Badge.vue
+++ b/src/components/Badge/Badge.vue
@@ -7,7 +7,7 @@
                { 'bg-white-300 text-gray-500': info },
                { 'bg-mint-100 text-mint-900': success },
                { 'bg-lemon-100 text-lemon-900': warning },
-               { 'bg-coral-100 text-coral-900': error },
+               { 'bg-coral-100 text-error': error },
                { 'bg-turquoise-100 text-turquoise-900': turquoise },
                { 'bg-flint-100 text-gray-700': flint },
                { '!py-0.5': small }

--- a/src/components/NewButton/NewButton.vue
+++ b/src/components/NewButton/NewButton.vue
@@ -12,10 +12,10 @@
       { 'focus-visible:ring-primary-100': !warning },
       { 'focus-visible:ring-coral-700': warning },
       { 'primary  bg-primary-500 text-white active:bg-black disabled:bg-gray-100': primary && !warning },
-      { 'primary warning bg-coral-900 text-white active:bg-coral-700 disabled:bg-coral-200': primary && warning },
+      { 'primary warning bg-error text-white active:bg-coral-700 disabled:bg-coral-200': primary && warning },
       { 'secondary border border-primary-500 bg-white text-primary-500': secondary && !warning,
         'disabled:border-gray-100 disabled:text-gray-100 active:border-black active:text-black': secondary && !warning },
-      { 'secondary border border-coral-900 bg-white text-coral-900': secondary && warning,
+      { 'secondary border border-error bg-white text-error': secondary && warning,
         'disabled:border-coral-200 disabled:text-coral-200 active:border-coral-700 active:text-coral-700': secondary && warning }
     ]"
     :disabled="disabled"

--- a/src/components/NewLink/NewLink.vue
+++ b/src/components/NewLink/NewLink.vue
@@ -22,13 +22,13 @@
         { 'px-6 text-sm h-[32px]': small && (primary || secondary) },
         { 'primary bg-primary-500 !text-white active:bg-black': !disabled && primary && !warning },
         { 'bg-gray-100 !text-white': disabled && primary && !warning },
-        { 'primary warning bg-coral-900 !text-white active:bg-coral-700': !disabled && primary && warning },
+        { 'primary warning bg-error !text-white active:bg-coral-700': !disabled && primary && warning },
         { 'bg-coral-200 !text-white': disabled && primary && warning },
         { 'secondary border border-primary-500 bg-white text-primary-500': !disabled && secondary && !warning,
           'focus:border-primary-500 active:border-black active:text-black': !disabled && secondary && !warning },
         { 'border border-gray-100 text-gray-100': disabled && secondary && !warning },
-        { 'secondary border border-coral-900 bg-white !text-coral-900': !disabled && secondary && warning,
-          'focus:border-coral-900 active:border-coral-700 active:!text-coral-700': !disabled && secondary && warning },
+        { 'secondary border border-error bg-white !text-error': !disabled && secondary && warning,
+          'focus:border-error active:border-coral-700 active:!text-coral-700': !disabled && secondary && warning },
         { 'border border-coral-200 text-coral-200': disabled && secondary && warning }
       ]"
       v-bind="$attrs"

--- a/src/components/NewLink/__tests__/NewLink.spec.js
+++ b/src/components/NewLink/__tests__/NewLink.spec.js
@@ -132,7 +132,7 @@ describe('Link', () => {
 
     const linkContent = queryByText(slotContent);
     expect(linkContent).toBeInTheDocument();
-    expect(linkContent).toHaveClass('primary bg-coral-900');
+    expect(linkContent).toHaveClass('primary bg-error');
   });
 
 });


### PR DESCRIPTION
## JIRA

JIRA [DANG-1295](https://lobsters.atlassian.net/browse/DANG-1295)

<img width="435" alt="Screen Shot 2022-06-08 at 11 46 16 AM" src="https://user-images.githubusercontent.com/50080618/172717085-89c4e652-223c-413c-9057-2b06fb8617d9.png">

## Description

- updates the TW plugin to bring on the new error color #D75A5A
- fixes a couple discrepancies where components were using `coral-900` instead of `error`

[TW plugin commit for reference](https://github.com/lob/tailwind-plugin-lob/pull/31)