### PR TITLE
Fix buttons warning colors - new branch to fix the preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.0.0-beta.21
+
+### Bug Fixes
+
+Fixes the warning background color of NewButton and NewLink components.
+
 ## 1.0.0-beta.20
 
 ### Bug Fixes
@@ -11,6 +17,13 @@ Fixes error background color of [TextInput component](./src/components/TextInput
 ### Features
 
 Added [Calendar component](./src/components/Calendar/Calendar.mdx):
+
+## 1.0.0-beta.19
+
+### Features
+
+Added [Calendar component](./src/components/Calendar/Calendar.mdx):
+
 ## 1.0.0-beta.18
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.20",
+  "version": "1.0.0-beta.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "1.0.0-beta.20",
+      "version": "1.0.0-beta.21",
       "dependencies": {
         "date-fns": "^2.23.0",
         "mitt": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.20",
+  "version": "1.0.0-beta.21",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/NewButton/NewButton.vue
+++ b/src/components/NewButton/NewButton.vue
@@ -12,10 +12,10 @@
       { 'focus-visible:ring-primary-100': !warning },
       { 'focus-visible:ring-coral-700': warning },
       { 'primary  bg-primary-500 text-white active:bg-black disabled:bg-gray-100': primary && !warning },
-      { 'primary warning bg-error text-white active:bg-coral-700 disabled:bg-coral-200': primary && warning },
+      { 'primary warning bg-coral-900 text-white active:bg-coral-700 disabled:bg-coral-200': primary && warning },
       { 'secondary border border-primary-500 bg-white text-primary-500': secondary && !warning,
         'disabled:border-gray-100 disabled:text-gray-100 active:border-black active:text-black': secondary && !warning },
-      { 'secondary border border-error bg-white text-error': secondary && warning,
+      { 'secondary border border-coral-900 bg-white text-coral-900': secondary && warning,
         'disabled:border-coral-200 disabled:text-coral-200 active:border-coral-700 active:text-coral-700': secondary && warning }
     ]"
     :disabled="disabled"

--- a/src/components/NewLink/NewLink.vue
+++ b/src/components/NewLink/NewLink.vue
@@ -22,13 +22,13 @@
         { 'px-6 text-sm h-[32px]': small && (primary || secondary) },
         { 'primary bg-primary-500 !text-white active:bg-black': !disabled && primary && !warning },
         { 'bg-gray-100 !text-white': disabled && primary && !warning },
-        { 'primary warning bg-error !text-white active:bg-coral-700': !disabled && primary && warning },
+        { 'primary warning bg-coral-900 !text-white active:bg-coral-700': !disabled && primary && warning },
         { 'bg-coral-200 !text-white': disabled && primary && warning },
         { 'secondary border border-primary-500 bg-white text-primary-500': !disabled && secondary && !warning,
           'focus:border-primary-500 active:border-black active:text-black': !disabled && secondary && !warning },
         { 'border border-gray-100 text-gray-100': disabled && secondary && !warning },
-        { 'secondary border border-error bg-white !text-error': !disabled && secondary && warning,
-          'focus:border-error active:border-coral-700 active:!text-coral-700': !disabled && secondary && warning },
+        { 'secondary border border-coral-900 bg-white !text-coral-900': !disabled && secondary && warning,
+          'focus:border-coral-900 active:border-coral-700 active:!text-coral-700': !disabled && secondary && warning },
         { 'border border-coral-200 text-coral-200': disabled && secondary && warning }
       ]"
       v-bind="$attrs"

--- a/src/components/NewLink/__tests__/NewLink.spec.js
+++ b/src/components/NewLink/__tests__/NewLink.spec.js
@@ -132,7 +132,7 @@ describe('Link', () => {
 
     const linkContent = queryByText(slotContent);
     expect(linkContent).toBeInTheDocument();
-    expect(linkContent).toHaveClass('primary bg-error');
+    expect(linkContent).toHaveClass('primary bg-coral-900');
   });
 
 });


### PR DESCRIPTION
The warning button should still be dark red, so 'coral-900'. (not 'error')