### PR TITLE
fix: change the export name of the ToolTip icon to ToolTipIcon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # CHANGELOG
 
+
+## 1.0.0-beta.23
+
+### Bug Fixes
+
+Renames the export of the new ToolTip icon to `ToolTipIcon`.
 ## 1.0.0-beta.22
+
+### Bug Fixes
 
 Removes external right margin of [MegaButton component](./src/components/MegaButton/MegaButton.mdx).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "1.0.0-beta.21",
+      "version": "1.0.0-beta.23",
       "dependencies": {
         "date-fns": "^2.23.0",
         "mitt": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/Icons/ToolTip.vue
+++ b/src/components/Icons/ToolTip.vue
@@ -19,6 +19,6 @@
 
 <script>
 export default {
-  name: 'ToolTip'
+  name: 'ToolTipIcon'
 };
 </script>


### PR DESCRIPTION
to avoid the clash with the Tooltip component