### PR TITLE
DANG-1280: dropdown hover/selector bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+## 1.0.0-beta.24
+Fixes a bug where the dropdown hover action is selecting and setting an option
 
 ## 1.0.0-beta.23
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.23",
+  "version": "1.0.0-beta.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "1.0.0-beta.23",
+      "version": "1.0.0-beta.24",
       "dependencies": {
         "date-fns": "^2.23.0",
         "mitt": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.23",
+  "version": "1.0.0-beta.24",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/Dropdown/Dropdown.vue
+++ b/src/components/Dropdown/Dropdown.vue
@@ -519,14 +519,13 @@ export default {
         this.onOptionChange(searchIndex);
       }
     },
-    onSelectBlur ($event) {
+    onSelectBlur () {
       if (this.ignoreBlur) {
         this.ignoreBlur = false;
         return;
       }
 
       if (this.open) {
-        this.selectOption($event, this.activeIndex);
         this.updateMenuState(false, false);
       }
     },

--- a/src/components/Dropdown/__tests__/Dropdown.spec.js
+++ b/src/components/Dropdown/__tests__/Dropdown.spec.js
@@ -423,8 +423,8 @@ describe('Dropdown', () => {
       // tabbing fires a FocusEvent (blur == focus away)
       await fireEvent.blur(select);
       const emittedEvent = emitted();
-      expect(emittedEvent).toHaveProperty('input');
-      expect(emittedEvent.input[0][0]).toEqual(props.options[0]);
+      expect(emittedEvent).not.toHaveProperty('input');
+      expect(emittedEvent).not.toHaveProperty('change');
     });
 
     it('clicking the select, it closes the listbox and retains focus', async () => {


### PR DESCRIPTION
## JIRA
https://lobsters.atlassian.net/browse/DANG-1280

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description
For a dropdown if you hover on an option and then click outside of the dropdown to close it without selecting an option, it selects the option that was last hovered when your cursor was still over the dropdown drawer
This was because the `onBlur` event was firing and calling `selectOption`. 
So i've removed that call to `selectOption`.

https://www.loom.com/share/3cd6770cece94213acf87cdb9ac547eb


<!--
## Screenshots
- before and after screenshots for features with visual changes
-->


## Tests
- In the drowdown component -> open the dropdown drawer (is this the correct term?) -> move the mouse over any option -> click somewhere else on the screen to close the dropdown => the dropdown option should still show the placeholder value.
- In the drowdown component -> open the dropdown drawer -> select an option -> open the dropdown drawer again -> move the mouse over any option -> click somewhere else on the screen to close the dropdown => the dropdown option should still show the previously selected value.

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
