### PR TITLE
DANG-1289 fix megabutton text color

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.25",
+  "version": "1.0.0-beta.26",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.25",
+  "version": "1.0.0-beta.26",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/MegaButton/MegaButton.vue
+++ b/src/components/MegaButton/MegaButton.vue
@@ -14,6 +14,7 @@
     <label
       :for="id"
       :class="[
+        'text-gray-900',
         'h-full flex justify-center items-center relative cursor-pointer',
         'rounded-lg border-2 border-transparent ring-4 ring-transparent shadow-input',
         'peer-focus:ring-primary-100 peer-focus:ring-4',


### PR DESCRIPTION
## JIRA
https://lobsters.atlassian.net/browse/DANG-1289

## Description

Fixes the megabuttons text color from ` text-gray-700` to `text-gray-900`

## Screenshots
Before:
<img width="313" alt="Screen Shot 2022-06-17 at 2 23 47 PM" src="https://user-images.githubusercontent.com/76072321/174356104-9c3ae00f-4196-43db-bc8f-9ca3ced45652.png">

After:
<img width="297" alt="Screen Shot 2022-06-17 at 2 28 01 PM" src="https://user-images.githubusercontent.com/76072321/174356701-892b71f9-0162-4b51-be8d-2b1cc4d4415d.png">
