### PR TITLE
updates TextInput hover & focus style 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 Updates the styling of the `TextInput` & `TextArea` components
+Removes the `disabled` prop from the `Label` component
 
 ## 1.0.0-beta.35
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.0.0-beta.36
+
+### Features
+
+Updates the styling of the `TextInput` & `TextArea` components
+
 ## 1.0.0-beta.35
 
 ### Bug fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.35",
+  "version": "1.0.0-beta.36",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "1.0.0-beta.35",
+      "version": "1.0.0-beta.36",
       "dependencies": {
         "date-fns": "^2.23.0",
         "mitt": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.35",
+  "version": "1.0.0-beta.36",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/LobLabel/LobLabel.vue
+++ b/src/components/LobLabel/LobLabel.vue
@@ -3,7 +3,6 @@
     <label
       :for="labelFor"
       :class="[
-        {'text-gray-100' : disabled },
         {'flex items-center justify-between mb-2 text-sm text-gray-500': !srOnlyLabel},
         { 'sr-only': srOnlyLabel }
       ]"
@@ -51,8 +50,7 @@ export default defineComponent({
     labelFor: { type: String, required: true },
     required: { type: Boolean, default: false },
     srOnlyLabel: { type: Boolean, default: false },
-    tooltipContent: { type: String, default: null },
-    disabled: { type: Boolean, default: false }
+    tooltipContent: { type: String, default: null }
   },
   computed: {
     tooltip () {

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -44,13 +44,13 @@
       :class="[
         'bg-white h-12 pl-4 pr-4 py-2.5 rounded-lg flex items-center gap-2 border border-gray-100 focus-within:outline-none',
         { '!pl-3 !pr-3 !h-8 !gap-1' : small },
-        {'hover:shadow focus-within:shadow focus-within:ring-1 focus-within:ring-primary-500 focus-within:border-primary-500': !disabled && !readonly},
+        {'hover:border-gray-300 focus-within:ring-1 focus-within:ring-primary-500 focus-within:border-primary-500': !disabled && !readonly},
         {'!bg-white-100' : disabled},
         {'!bg-white-100 focus-within:ring-1 focus-within:ring-primary-500 focus-within:border-primary-500' : readonly},
         {'!border-coral-700 !bg-coral-100 focus-within:ring-1 focus-within:ring-coral-700': error},
         {'!bg-white-100' : withCopyButton},
         {'!flex-wrap !h-fit' : isMultiselect},
-        {'border-gray-500 focus-within:border-primary-500' : modelValue && !error && !withCopyButton}
+        {'focus-within:border-primary-500' : modelValue && !error && !withCopyButton}
       ]"
     >
       <div
@@ -74,7 +74,7 @@
           {'text-xs': small},
           {'truncate': withCopyButton},
           {'bg-white-100 cursor-not-allowed !text-gray-100 !placeholder-gray-100': disabled || readonly},
-          {'bg-coral-100 !placeholder-error !text-error !autofill:bg-coral-100 errorAutofill': error}
+          {'bg-coral-100 !placeholder-error !autofill:bg-coral-100 errorAutofill': error}
         ]"
         :disabled="disabled"
         :required="required"

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -68,7 +68,7 @@
         :max="max"
         :pattern="pattern"
         :class="[
-          `leading-5 w-full text-gray-900 placeholder-gray-500 placeholder:font-light outline-none ${inputClass}`,
+          `leading-5 w-full text-gray-900 placeholder-gray-100 placeholder:font-light outline-none ${inputClass}`,
           {'nonErrorAutofill' : !disabled && !readonly},
           {'text-xs': small},
           {'truncate': withCopyButton},

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -7,7 +7,6 @@
       :required="required"
       :sr-only-label="srOnlyLabel"
       :tooltip-content="tooltipContent"
-      :disabled="disabled"
     />
     <div
       v-if="withCopyButton"

--- a/src/components/Textarea/Textarea.vue
+++ b/src/components/Textarea/Textarea.vue
@@ -17,12 +17,11 @@
       :readonly="readonly"
       :placeholder="placeholder"
       :class="[
-        `bg-white text-gray-500 placeholder-gray-100 p-4 resize-none rounded-lg border border-gray-100 focus-within:outline-none w-full h-40 ${inputClass}`,
+        `bg-white text-gray-500 placeholder-gray-100 placeholder:font-light p-4 resize-none rounded-lg border border-gray-100 focus-within:outline-none w-full h-40 ${inputClass}`,
         { 'border-error': error },
         { '!bg-white-300 cursor-not-allowed': disabled || readonly },
-        { 'hover:shadow focus-within:shadow focus-within:ring-1 focus-within:ring-primary-500 focus-within:border-primary-500': !disabled && !readonly },
-        { 'hover:shadow': !disabled && !readonly },
-        {'border-gray-500 focus-within:border-primary-500' : modelValue }
+        { 'hover:border-gray-500 focus-within:ring-1 focus-within:ring-primary-500 focus-within:border-primary-500': !disabled && !readonly },
+        { 'border-gray-500 focus-within:border-primary-500' : modelValue }
       ]"
       @input="onInput"
     />


### PR DESCRIPTION
Changes as advised by Tim/Shampa during design live session.

**[figma ref](https://www.figma.com/file/jJIuBK6U2i50x4v7c9jbrF/Lob-Design-System-2.0?node-id=931%3A6538)**

## Description

- removes the shadow on hover
- focus shows a gray-300 border instead
- input with value but unfocused maintains the gray-100 border
- the error state text color is the default
- removes the disabled prop from LobLabel - the label will stay the same color when TextInput is disabled

will add the changelog & package changes when it is time to merge :)