### PR TITLE
fix: maintain text-gray-500 on hover for NewLink secondary-button variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.0.0-beta.32
+
+### Bug Fixes
+
+Maintain the text color on hover for the secondary-button variant on `NewLink`
+
 ## 1.0.0-beta.31
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.31",
+  "version": "1.0.0-beta.32",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "1.0.0-beta.31",
+      "version": "1.0.0-beta.32",
       "dependencies": {
         "date-fns": "^2.23.0",
         "mitt": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.31",
+  "version": "1.0.0-beta.32",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/NewLink/NewLink.vue
+++ b/src/components/NewLink/NewLink.vue
@@ -22,7 +22,7 @@
         { 'bg-gray-100 !text-white': disabled && primary && !warning },
         { 'primary warning !text-white': !disabled && primary && warning },
         { 'bg-coral-200 !text-white': disabled && primary && warning },
-        { 'secondary border !border-gray-300 text-gray-500 hover:bg-gray-100/[.15] active:bg-gray-100/[.25]': !disabled && secondary && !warning },
+        { 'secondary border !border-gray-300 text-gray-500 hover:text-gray-500 hover:bg-gray-100/[.15] active:bg-gray-100/[.25]': !disabled && secondary && !warning },
         { 'border border-gray-100 text-gray-100': disabled && secondary && !warning },
         { 'secondary bg-white border !border-chili text-chili hover:bg-chili/[.04] active:bg-chili/[.08]': !disabled && secondary && warning },
         { 'border border-coral-200 text-coral-200': disabled && secondary && warning }


### PR DESCRIPTION
tiny nit and not reproducible on storybook

the text on a `NewLink variant="secondary-button"` turns blue on hover when it is pointing to an internal route. Hopefully this fixes it.