### PR TITLE
fix: active background color in newlink (button style)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.0.0-beta.35
+
+### Bug fixes
+
+Maintain the gradient background on primary-button variant of `NewLink` when active
+
 ## 1.0.0-beta.34
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.34",
+  "version": "1.0.0-beta.35",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "1.0.0-beta.34",
+      "version": "1.0.0-beta.35",
       "dependencies": {
         "date-fns": "^2.23.0",
         "mitt": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.34",
+  "version": "1.0.0-beta.35",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/NewLink/NewLink.vue
+++ b/src/components/NewLink/NewLink.vue
@@ -18,7 +18,7 @@
         { 'focus-visible:ring-4 focus-visible:ring-primary-100 focus:ring-transparent focus:outline-none active:scale-[.96]': primary || secondary },
         { 'px-6 text-base h-[48px]': regular && (primary || secondary) },
         { 'px-4 text-sm h-[32px]': small && (primary || secondary) },
-        { 'primary bg-primary-500 !text-white ': !disabled && primary && !warning },
+        { 'primary !text-white ': !disabled && primary && !warning },
         { 'bg-gray-100 !text-white': disabled && primary && !warning },
         { 'primary warning !text-white': !disabled && primary && warning },
         { 'bg-coral-200 !text-white': disabled && primary && warning },
@@ -121,16 +121,16 @@ export default {
 </script>
 
 <style scoped lang="scss">
-.primary:not(:disabled):not(:active) {
+.primary:not(:disabled) {
   background: linear-gradient(114.08deg, #1876db 7.95%, #5748ff 90.87%);
 }
 
-.primary:focus:not(:active):not(:disabled),
+.primary:focus:not(:disabled),
 .primary:hover:not(:disabled):not(:focus) {
   background: linear-gradient(114.08deg, #5748ff 7.95%, #1876db 90.87%);
 }
 
-.primary.warning:not(:disabled):not(:active) {
+.primary.warning:not(:disabled) {
   background: linear-gradient(114.08deg, #db1818 7.95%, #ec4949 90.87%);
 }
 


### PR DESCRIPTION
Removes the blue bg-color (remnant) and the `:not(:active)` variant from the styleblocks, so that the bg gradient stays the same across default/hover/active etc. 
The NewButton had the correct combo but the NewLink didn't. 