### PR TITLE
DANG-1393 / fix the Colors story so that all colors display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "sass-loader": "^10.1.1",
         "stylelint": "^13.13.1",
         "stylelint-config-standard": "^22.0.0",
-        "tailwind-plugin-lob": "^0.0.39",
+        "tailwind-plugin-lob": "^0.0.41",
         "tailwindcss": "^3.0.24",
         "typescript": "~3.9.3",
         "vite": "^2.9.13",
@@ -20756,9 +20756,9 @@
       "dev": true
     },
     "node_modules/tailwind-plugin-lob": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/tailwind-plugin-lob/-/tailwind-plugin-lob-0.0.39.tgz",
-      "integrity": "sha512-oslgaJQsG3mjyzpsuNYK4ILKl1Z3MyF9rkv73FZFni55VVjz8jwvWJZtae+s6uqg+BRfZyOlepN5wWX6y6YVBg==",
+      "version": "0.0.41",
+      "resolved": "https://registry.npmjs.org/tailwind-plugin-lob/-/tailwind-plugin-lob-0.0.41.tgz",
+      "integrity": "sha512-lKNEPEI7Oshd2O3WCcgw201Tc3xoVpTrvuOUYE6zjRtfQxY6EhqZedn5sNoheIGZYFNeL4dJHYIGMUfJTK/SPA==",
       "dev": true,
       "engines": {
         "node": ">=14.18.2"
@@ -39901,9 +39901,9 @@
       }
     },
     "tailwind-plugin-lob": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/tailwind-plugin-lob/-/tailwind-plugin-lob-0.0.39.tgz",
-      "integrity": "sha512-oslgaJQsG3mjyzpsuNYK4ILKl1Z3MyF9rkv73FZFni55VVjz8jwvWJZtae+s6uqg+BRfZyOlepN5wWX6y6YVBg==",
+      "version": "0.0.41",
+      "resolved": "https://registry.npmjs.org/tailwind-plugin-lob/-/tailwind-plugin-lob-0.0.41.tgz",
+      "integrity": "sha512-lKNEPEI7Oshd2O3WCcgw201Tc3xoVpTrvuOUYE6zjRtfQxY6EhqZedn5sNoheIGZYFNeL4dJHYIGMUfJTK/SPA==",
       "dev": true
     },
     "tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "sass-loader": "^10.1.1",
     "stylelint": "^13.13.1",
     "stylelint-config-standard": "^22.0.0",
-    "tailwind-plugin-lob": "^0.0.39",
+    "tailwind-plugin-lob": "^0.0.41",
     "tailwindcss": "^3.0.24",
     "typescript": "~3.9.3",
     "vite": "^2.9.13",

--- a/src/theme/colors/Colors.vue
+++ b/src/theme/colors/Colors.vue
@@ -3,14 +3,13 @@
     <div
       v-for="color in Object.keys(themeColors)"
       :key="color"
-      class="pb-8"
+      class="mb-5"
     >
-      <h1
-        :class="`text-${color}`"
-      >
-        {{ color }}
-      </h1>
-
+      <div v-if="typeof themeColors[color] !== 'object'">
+        <h2 :class="`text-${color}`">
+          {{ color }}
+        </h2>
+      </div>
       <template
         v-if="typeof themeColors[color] === 'object'"
       >
@@ -18,12 +17,12 @@
           v-for="nestedColor in Object.keys(themeColors[color])"
           :key="nestedColor"
         >
-          <h1
+          <h2
             v-if="typeof themeColors[color][nestedColor] === 'string' && nestedColor !== 'DEFAULT'"
             :class="`text-${color}-${nestedColor}`"
           >
             {{ color }}-{{ nestedColor }} ({{ theme.colors[color][nestedColor].toUpperCase() }})
-          </h1>
+          </h2>
         </div>
       </template>
     </div>
@@ -40,6 +39,8 @@ export default {
   name: 'Theme',
   computed: {
     themeColors () {
+      delete colors.transparent;
+      delete colors.current;
       return colors;
     },
     theme () {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,7 @@ module.exports = {
       pattern: /text-(transparent|current|black|success|lavender|papaya)/
     },
     {
-      pattern: /text-(primary|secondary|lemon|turquoise|flint|mint|coral|gray|white)-(100|300|500|700|900)/
+      pattern: /text-(primary|secondary|lemon|turquoise|flint|mint|coral|gray|white)-(100|200|300|500|700|900)/
     }
   ],
   plugins: [

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,7 @@ module.exports = {
   content: ['./src/**/*.vue'],
   safelist: [
     {
-      pattern: /text-(transparent|current|black|success|lavender|papaya)/
+      pattern: /text-(black|warning|error|success|lavender|chili|papaya)/
     },
     {
       pattern: /text-(primary|secondary|lemon|turquoise|flint|mint|coral|gray|white)-(100|200|300|500|700|900)/

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,13 @@
 module.exports = {
   content: ['./src/**/*.vue'],
+  safelist: [
+    {
+      pattern: /text-(transparent|current|black|success|lavender|papaya)/
+    },
+    {
+      pattern: /text-(primary|secondary|lemon|turquoise|flint|mint|coral|gray|white)-(100|300|500|700|900)/
+    }
+  ],
   plugins: [
     require('tailwind-plugin-lob')
   ]


### PR DESCRIPTION
## JIRA

ui-components stories for FontSize, Color, & Typography need fixing/updating - This PR is for Colors only
[DANG-1393](https://lobsters.atlassian.net/browse/DANG-1393)

## Description

- includes this change: [removed all tertiary colors from the config](https://github.com/lob/tailwind-plugin-lob/pull/37).
- removes transparent & current from the Story
- whitelists all colors
- changed to h2 because it looks better to me but open to all ideas :)))



## **Colors story before & after:** **[current link](https://ui-components.lob.com/?path=/story/theme-dev-only-colors--primary) VS [demo link](https://deploy-preview-305--elegant-yalow-f821c3.netlify.app/?path=/story/theme-dev-only-colors--primary)**


<img width="600" alt="Screen Shot 2022-07-06 at 2 52 28 PM" src="https://user-images.githubusercontent.com/50080618/177622467-dae4b8b3-f2bc-4078-a22a-fc1e8f212133.png"> <img width="600" alt="Screen Shot 2022-07-06 at 2 52 19 PM" src="https://user-images.githubusercontent.com/50080618/177622470-e11bdf9c-0277-47ab-a6cf-2df41668841a.png">

