### PR TITLE
Dang 975/accordion color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.0.0-beta.38
+
+### Features
+
+Changed the color of `Accordion` component for better contrast/accessibility
+
 ## 1.0.0-beta.37
 
 ### Bug fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.37",
+  "version": "1.0.0-beta.38",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "1.0.0-beta.37",
+      "version": "1.0.0-beta.38",
       "dependencies": {
         "date-fns": "^2.23.0",
         "mitt": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.37",
+  "version": "1.0.0-beta.38",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/Accordion/Accordion.vue
+++ b/src/components/Accordion/Accordion.vue
@@ -8,14 +8,14 @@
     role="button"
     @click="expanded = !expanded"
   >
-    <h2 class="text-primary-300 py-3 font-light text-lg">
+    <h2 class="text-primary-500 py-3 font-light text-lg">
       {{ title }}
     </h2>
     <div
       class="flex-end py-3.5"
     >
       <ChevronRight
-        class="w-6 h-6 text-primary-300"
+        class="w-6 h-6 text-primary-500"
         :class="['transition-transform duration-200 ease-linear -mr-1', {'xl:transform xl:rotate-90': expanded}]"
       />
     </div>


### PR DESCRIPTION
## JIRA

[DANG-975 Accordion > header color doesn't have sufficient contrast](https://lobsters.atlassian.net/browse/DANG-975)

## Description

- changed text & icon color from primary-300 to 500

**before // after :**

<img width="340" alt="Screen Shot 2022-07-07 at 9 40 14 AM" src="https://user-images.githubusercontent.com/50080618/177787923-c3ec20c1-967b-489f-ad69-e0a6346424f0.png"> <img width="340" alt="Screen Shot 2022-07-07 at 9 39 52 AM" src="https://user-images.githubusercontent.com/50080618/177787924-819b3351-cf3f-4e4c-bf30-f8df1406d7b0.png">

