### PR TITLE
DANG-756/active-route-bug-fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 1.0.0-beta.39
 
+### Bug fixes
+
+Makes `MainNavigationChildItem` be active when its `to` prop starts with the current route, instead of when it includes it. This way, a component with `to = /logs` won't be active when the current route is something like `/settings/logs`.
+
+## 1.0.0-beta.39
+
 ### Features
 
 Made the close (X) icon of the `Modal` larger, added background color on hover

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-Makes `MainNavigationChildItem` be active when its `to` prop starts with the current route, instead of when it includes it. This way, a component with `to = /logs` won't be active when the current route is something like `/settings/logs`.
+Changes the `MainNavigationChildItem` component's logic for its active state to the following: when its `to` prop starts with the current route, instead of when it includes it. This way, a component with `to = /logs` won't be active when the current route is something like `/settings/logs`.
 
 ## 1.0.0-beta.39
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.39",
+  "version": "1.0.0-beta.40",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/MainNavigation/MainNavigationChildItem.vue
+++ b/src/components/MainNavigation/MainNavigationChildItem.vue
@@ -36,7 +36,7 @@ export default {
   emits: ['nav'],
   computed: {
     active () {
-      return this.$route.path.includes(this.to);
+      return this.$route.path.startsWith(this.to);
     }
   },
   methods: {


### PR DESCRIPTION
## JIRA

[DANG-756](https://lobsters.atlassian.net/browse/DANG-756)

## Description

In the dashboard, there were (at least) 3 cases in which a `MainNavigationChildItem` would incorrectly render with an active state, although we were not visiting its page:

1. When visiting `/settings/logs`, navigation item `API Logs (/logs)` would get the active state too
2. When visiting `/settings/editions/us-verifications`, `US Verifications (/us-verifications)` would get the active state too
3. When visiting `/settings/editions/intl-verifications`, `Int'l Verifications (/intl-verifications)` would get the active state too

Case 1:
![image](https://user-images.githubusercontent.com/83967528/178011427-12302b9f-d3d2-42f9-b7b5-6ddc4493b7f9.png)

Case 2:
![image](https://user-images.githubusercontent.com/83967528/178011232-131c7597-cb4a-40bd-a99f-668c5e546c0f.png)

## Fix

I changed the active state to only be true when the `to` prop **starts with** the current route, instead of just includes it. You can see in the examples above how the previous behavior was triggering the bug.
