### PR TITLE
Restores error status to radio buttons

### DIFF
--- a/src/components/RadioButton/RadioButton.vue
+++ b/src/components/RadioButton/RadioButton.vue
@@ -9,6 +9,7 @@
       type="radio"
       :class="[
         'm-0 p-0 opacity-0 mt-2',
+        {'radio__input--error': error},
         {'!cursor-not-allowed': disabled}
       ]"
       :name="name"
@@ -38,6 +39,7 @@
       <div
         :class="[
           'text-sm ml-4 text-gray-300 !font-normal',
+          {'!text-coral-900' : error},
           {'!text-primary-500' : checked},
           {'!text-gray-100' : disabled}
         ]"
@@ -95,6 +97,10 @@ export default {
       default: false
     },
     largeHover: {
+      type: Boolean,
+      default: false
+    },
+    error: {
       type: Boolean,
       default: false
     }
@@ -204,8 +210,39 @@ input {
     @apply border-gray-900;
   }
 
-  &:not(:disabled):not(:checked) + label.largeHover::before {
-    @apply border-gray-900;
+  &.radio__input--error + label::before {
+    @apply border-error;
+  }
+
+  &.radio__input--error:focus + label.largeButton::before {
+    @apply shadow-none;
+  }
+
+  &.radio__input--error:focus:checked + label.largeButton::before {
+    @apply border-error;
+  }
+
+  &.radio__input--error:checked + label::before {
+    @apply border-error;
+    @apply border;
+  }
+
+  &.radio__input--error:checked:focus + label::before {
+    @apply border-error;
+  }
+
+  &:hover:not(:disabled):not(:checked):not(.radio__input--error) + label::before {
+    @apply shadow-input;
+    @apply border-primary-500;
+  }
+
+  &:not(:disabled):not(:checked):not(.radio__input--error) + label.largeHover::before {
+    @apply shadow-input;
+    @apply border-primary-500;
+  }
+
+  &.radio__input--error:checked + label::after {
+    @apply bg-transparent;
   }
 }
 </style>

--- a/src/components/RadioButton/__tests__/RadioButton.spec.js
+++ b/src/components/RadioButton/__tests__/RadioButton.spec.js
@@ -9,6 +9,7 @@ const initialProps = {
   name: 'test name',
   label: 'Test',
   value: 'test',
+  errir: false,
   disabled: false
 };
 
@@ -35,6 +36,20 @@ describe('Radio Button', () => {
 
     const radio = getByLabelText(props.label);
     expect(radio).toBeChecked();
+  });
+
+  it('adds an error class to the input when error prop is true', () => {
+    const props = {
+      ...initialProps,
+      error: true
+    };
+
+    const { getByLabelText } = render(RadioButton, {
+      props
+    });
+
+    const radio = getByLabelText(props.label);
+    expect(radio).toHaveClass('radio__input--error');
   });
 
   it('disables the input when disabled prop is true', () => {

--- a/src/components/RadioButtonLarge/RadioButtonLarge.vue
+++ b/src/components/RadioButtonLarge/RadioButtonLarge.vue
@@ -9,11 +9,12 @@
       :class="[
         'cursor-pointer bg-white h-12 top-2 inline-block mr-4 mt-1 border border-gray-100 w-[200px] rounded-lg pl-2',
         {'hover:border-gray-300': !disabled},
-        {'!border-primary-500 ring-inset ring-1 ring-primary-500' : checked && !disabled},
-        {'h-[60px]' : helperText},
-        {'hover:h-[60px]' : revealText},
+        {'!border-primary-500 ring-inset ring-1 ring-primary-500': checked && !disabled && !error},
+        {'h-[60px]': helperText},
+        {'hover:h-[60px]': revealText},
         {'h-[60px]' : revealText && checked},
-        {'bg-white-100 !cursor-not-allowed': disabled}
+        {'bg-white-100 !cursor-not-allowed': disabled},
+        {'!border-coral-700': error}
       ]"
       @mouseenter="onContainerHover"
       @mouseleave="onContainerLeaveHover"
@@ -38,6 +39,7 @@
           :large="true"
           :large-checked="checked"
           :large-hover="largeHover"
+          :error="error"
           @click="onClick"
           @input="onInput"
         />
@@ -80,6 +82,10 @@ export default {
     value: {
       type: [String, Boolean],
       default: ''
+    },
+    error: {
+      type: Boolean,
+      default: false
     },
     label: {
       type: String,

--- a/src/components/RadioButtonLarge/__tests__/RadioButtonLarge.spec.js
+++ b/src/components/RadioButtonLarge/__tests__/RadioButtonLarge.spec.js
@@ -9,6 +9,7 @@ const initialProps = {
   name: 'test name',
   label: 'Test',
   value: 'test',
+  error: false,
   disabled: false
 };
 
@@ -35,6 +36,20 @@ describe('Radio Button', () => {
 
     const radio = getByLabelText(props.label);
     expect(radio).toBeChecked();
+  });
+
+  it('adds an error class to the input when error prop is true', () => {
+    const props = {
+      ...initialProps,
+      error: true
+    };
+
+    const { getByLabelText } = render(RadioButtonLarge, {
+      props
+    });
+
+    const radio = getByLabelText(props.label);
+    expect(radio).toHaveClass('radio__input--error');
   });
 
   it('disables the input when disabled prop is true', () => {


### PR DESCRIPTION
## JIRA

This was blocking [DANG-1434](https://lobsters.atlassian.net/browse/DANG-1434) - show error state on requiered radio buttons which weren't selected.

## Description

Following [this slack thread](https://lob.slack.com/archives/C037J0X9PGD/p1657550623416409), we are restoring the error status to radio buttons, which was removed [here](https://github.com/lob/ui-components/commit/09959cecdbd7364580110f513a601983eb78c76c#diff-a78bb6b0f0f81c47b6a545dfca131ac43fc6e501b76e767c589d583012a8270f).
