### PR TITLE
Dang 1435/modal aria labels

### DIFF
--- a/src/components/Modal/Modal.stories.js
+++ b/src/components/Modal/Modal.stories.js
@@ -1,4 +1,5 @@
 import NewButton from '../NewButton/NewButton.vue';
+import Dropdown from '../Dropdown/Dropdown.vue';
 import RadioButton from '../RadioButton/RadioButton.vue';
 import RadioGroup from '../RadioGroup/RadioGroup.vue';
 import Modal from './Modal.vue';
@@ -53,6 +54,61 @@ const PrimaryTemplate = (args, { argTypes }) => ({
     `
 });
 
+const dropVModel = '';
+const WithDropdownTemplate = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { Modal, NewButton, Dropdown },
+  setup: () => ({ args }),
+  data: () => ({ isModalVisible, dropVModel }),
+  methods: {
+    closeModal () {
+      this.isModalVisible = false;
+    }
+  },
+  template: `
+    <NewButton @click="isModalVisible = true">
+      Open Modal
+    </NewButton>
+
+    <Modal
+      v-bind="args"
+      width="500px"
+      :visible="isModalVisible"
+      closeButtonAriaLabel="Close modal with dropdown"
+      @close="closeModal"
+    >
+      <template v-slot:header>
+        <h4>A Modal with a Dropdown</h4>
+      </template>
+
+      <template #default="{ events: { detectOpenDropdown } } ">
+        <div style="height: 150px;">
+          <div class="mb-5">Select a thing to continue:</div>
+          <Dropdown 
+            id="dropdown1" 
+            label="thing"
+            srOnlyLabel 
+            :options="['one', 'two']" 
+            v-model="dropVModel" />
+        </div>
+      </template>
+
+      <template v-slot:footer>
+        <div class="flex self-end">
+          <NewButton 
+          class="ml-2" 
+          :disabled="!dropVModel"
+          @click="isModalVisible=false">OK</NewButton>
+        </div>
+      </template>
+    </Modal>
+    `
+});
+
 export const Primary = PrimaryTemplate.bind({});
 Primary.args = {
+};
+
+export const WithDropdown = WithDropdownTemplate.bind({});
+WithDropdown.args = {
 };

--- a/src/components/Modal/Modal.stories.js
+++ b/src/components/Modal/Modal.stories.js
@@ -30,6 +30,7 @@ const PrimaryTemplate = (args, { argTypes }) => ({
     <Modal
       v-bind="args"
       :visible="isModalVisible"
+      closeButtonAriaLabel="Close Tracking Events Modal"
       @close="isModalVisible = false"
     >
       <template v-slot:header>

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -22,7 +22,7 @@
           <button
             :class="['rounded-full w-7 h-7 p-1 cursor-pointer hover:bg-white-200',
                      'focus:outline-none focus:ring-2 focus:ring-primary-100']"
-            aria-label="Close modal"
+            :aria-label="closeButtonAriaLabel"
             @click="closeModal"
             @keyup.enter="closeModal"
           >
@@ -61,6 +61,10 @@ export default {
     width: {
       type: String,
       default: ''
+    },
+    closeButtonAriaLabel: {
+      type: String,
+      default: 'Close modal'
     }
   },
   emits: ['close'],

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -38,9 +38,8 @@
           id="modalDescription"
           class="py-5"
         >
-          <slot />
+          <slot :events="{ detectOpenDropdown }" />
         </section>
-
         <footer
           v-if="hasFooter"
           class="flex border-t border-gray-100 flex-col pt-4"
@@ -86,6 +85,10 @@ export default {
     },
     getHeaderContent () {
       return this.$slots.header()[0].children || 'modal dialog';
+    },
+    detectOpenDropdown (val) {
+      //eslint-disable-next-line no-console
+      console.log('open dropdown val', val);
     }
   }
 };

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -3,14 +3,17 @@
     <div
       v-show="visible"
       :class="['fixed inset-0 flex items-center justify-center bg-black bg-opacity-60 z-30']"
+      :aria-hidden="!visible"
       @mousedown="closeModal"
     >
       <div
-        class="bg-white flex flex-col overflow-y-auto shadow rounded-lg p-5 max-h-5/6"
         role="dialog"
-        title="modal"
-        aria-labelledby="modal"
+        aria-modal="true"
+        :title="getHeaderContent()"
+        aria-labelledby="modalTitle"
+        aria-describedby="modalDescription"
         :style="{'width': width}"
+        class="bg-white flex flex-col overflow-y-auto shadow rounded-lg p-5 max-h-5/6"
         @mousedown.stop
       >
         <header
@@ -79,6 +82,9 @@ export default {
   methods: {
     closeModal () {
       this.$emit('close');
+    },
+    getHeaderContent () {
+      return this.$slots.header()[0].children || 'modal dialog';
     }
   }
 };

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -5,6 +5,7 @@
       :class="['fixed inset-0 flex items-center justify-center bg-black bg-opacity-60 z-30']"
       :aria-hidden="!visible"
       @mousedown="closeModal"
+      @keydown.esc="closeModal"
     >
       <div
         role="dialog"

--- a/src/components/Modal/__tests__/Modal.spec.js
+++ b/src/components/Modal/__tests__/Modal.spec.js
@@ -7,23 +7,22 @@ const renderComponent = (options) => render(Modal, { ...options });
 describe('Modal', () => {
 
   it('is hidden by default', () => {
-    const { queryByRole } = renderComponent();
+    const slots = { header: 'modal header' };
+    const { queryByRole } = renderComponent({ slots });
 
     const modal = queryByRole('dialog');
     expect(modal).not.toBeInTheDocument();
-
   });
 
   it('is visible when its visible prop is true', () => {
     const props = {
       visible: true
     };
-
-    const { queryByRole } = renderComponent({ props });
+    const slots = { header: 'modal header' };
+    const { queryByRole } = renderComponent({ slots, props });
 
     const modal = queryByRole('dialog');
     expect(modal).toBeInTheDocument();
-
   });
 
 });


### PR DESCRIPTION
## JIRA

[DANG-1435
replace hard-coded aria-labels in the Modal](https://lobsters.atlassian.net/browse/DANG-1435)

[DANG-913
[a11y] Modals should close when pressing "esc" unless a different element needs to be closed](https://lobsters.atlassian.net/browse/DANG-913)

TODO ^ Esc key should not close the Modal if the Modal has an open Dropdown in it

q: what should this ^ be based on? 
should the Dropdown emit whether it is open or not?
should the Modal look for an element with the role="listbox" and class hidden/block?
how can we make this a bit ore generic/catch all?
cc @erin-doyle 


