### PR TITLE
Dang 1429/red/text-error asterisk for all required input fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.0.0-beta.42
+
+### Features
+
+Adds `text-error` (red) color to the asterisk for all reaquired input fields
+
 ## 1.0.0-beta.41
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.39",
+  "version": "1.0.0-beta.42",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "1.0.0-beta.39",
+      "version": "1.0.0-beta.42",
       "dependencies": {
         "date-fns": "^2.23.0",
         "mitt": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.41",
+  "version": "1.0.0-beta.42",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/Checkbox/Checkbox.vue
+++ b/src/components/Checkbox/Checkbox.vue
@@ -31,7 +31,7 @@
     <span v-html="label" />
     <span
       v-if="required"
-      class="text-sm text-turquoise-900"
+      class="text-sm text-error"
     >
       *
     </span>

--- a/src/components/LobLabel/LobLabel.vue
+++ b/src/components/LobLabel/LobLabel.vue
@@ -11,7 +11,7 @@
         {{ label }}
         <span
           v-if="required"
-          class="text-sm text-turquoise-900"
+          class="text-sm text-error"
         >
           *
         </span>

--- a/src/components/RadioButton/RadioButton.vue
+++ b/src/components/RadioButton/RadioButton.vue
@@ -1,9 +1,5 @@
 <template>
-  <div
-    :class="[
-      'inline-block mr-6 mt-1'
-    ]"
-  >
+  <div class="inline-block mr-6 mt-1">
     <input
       :id="id"
       type="radio"

--- a/src/components/RadioGroup/RadioGroup.vue
+++ b/src/components/RadioGroup/RadioGroup.vue
@@ -9,7 +9,7 @@
       {{ legend }}
       <span
         v-if="required"
-        class="text-sm text-turquoise-900"
+        class="text-sm text-error"
       >
         *
       </span>

--- a/src/components/ToggleButton/ToggleButton.vue
+++ b/src/components/ToggleButton/ToggleButton.vue
@@ -30,7 +30,7 @@
       {{ label }}
       <span
         v-if="required"
-        class="text-sm text-turquoise-900"
+        class="text-sm text-error"
       >
         *
       </span>


### PR DESCRIPTION
## JIRA

[DANG-1429](https://lobsters.atlassian.net/browse/DANG-1429)

## Description
sample screenshots:

<img width="368" alt="Screen Shot 2022-07-12 at 4 14 54 PM" src="https://user-images.githubusercontent.com/50080618/178586820-7f1c54ab-c24a-413e-83dd-3931591e7979.png">
<img width="368" alt="Screen Shot 2022-07-12 at 4 14 38 PM" src="https://user-images.githubusercontent.com/50080618/178586821-dd507732-1699-469f-acdc-7982fc505664.png">
<img width="368" alt="Screen Shot 2022-07-12 at 4 14 24 PM" src="https://user-images.githubusercontent.com/50080618/178586824-0d7f9e3c-1e2a-4be1-b474-fcad1be83264.png">

