### PR TITLE
Dang 1455/add open/close:list & hover:option emits to Dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.0.0-beta.47
+
+### Features
+
+Add `isDrawerOpen` and `hoverOverIndex` emits to the `Dropdown` component
+
 ## 1.0.0-beta.46
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-Add `isDrawerOpen` and `hoverOverIndex` emits to the `Dropdown` component
+Add `open:list`, `close:list`, `hover:option` emits to the `Dropdown` component
 
 ## 1.0.0-beta.46
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.46",
+  "version": "1.0.0-beta.47",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "1.0.0-beta.46",
+      "version": "1.0.0-beta.47",
       "dependencies": {
         "date-fns": "^2.23.0",
         "mitt": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.46",
+  "version": "1.0.0-beta.47",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/Dropdown/Dropdown.vue
+++ b/src/components/Dropdown/Dropdown.vue
@@ -236,7 +236,7 @@ export default {
       default: null
     }
   },
-  emits: ['update:modelValue', 'input', 'change'],
+  emits: ['update:modelValue', 'input', 'change', 'isDrawerOpen', 'hoverOverIndex'],
   data () {
     return {
       // active option index
@@ -294,6 +294,9 @@ export default {
     }
   },
   watch: {
+    open (val) {
+      this.$emit('isDrawerOpen', val);
+    },
     options () {
       this.setSelectedInLifecycle();
     },
@@ -533,6 +536,7 @@ export default {
     },
     onOptionMouseover ($event, index) {
       this.onOptionChange(index);
+      this.$emit('hoverOverIndex', index);
     },
     onOptionChange (index) {
       this.activeIndex = index;

--- a/src/components/Dropdown/Dropdown.vue
+++ b/src/components/Dropdown/Dropdown.vue
@@ -236,7 +236,7 @@ export default {
       default: null
     }
   },
-  emits: ['update:modelValue', 'input', 'change', 'isDrawerOpen', 'hoverOverIndex'],
+  emits: ['update:modelValue', 'input', 'change', 'open:list', 'close:list', 'hover:option'],
   data () {
     return {
       // active option index
@@ -295,7 +295,7 @@ export default {
   },
   watch: {
     open (val) {
-      this.$emit('isDrawerOpen', val);
+      val ? this.$emit('open:list') : this.$emit('close:list');
     },
     options () {
       this.setSelectedInLifecycle();
@@ -536,7 +536,7 @@ export default {
     },
     onOptionMouseover ($event, index) {
       this.onOptionChange(index);
-      this.$emit('hoverOverIndex', index);
+      this.$emit('hover:option', index);
     },
     onOptionChange (index) {
       this.activeIndex = index;


### PR DESCRIPTION
## JIRA

part of [DANG-1455 ](https://lobsters.atlassian.net/browse/DANG-1455) Mapping Dropdown component

## Description

- adds isDrawerOpen and hoverOverIndex emits to Dropdown
update: renamed to `open:list`, `close:list`, & `hover:option`

We will use the emitted values to display the CSV Sample values next to the dropdown while the drawer is open and the user is hovering over the list.