### PR TITLE
dang-1448/ fix: add fileFor prop to Dropzone, update fileSizeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.0.0-beta.49
+
+### Features
+
+- add `fileFor` prop to the `Dropzone` component to update the 'fileSizeError' text
+
 ## 1.0.0-beta.48
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.48",
+  "version": "1.0.0-beta.49",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "1.0.0-beta.48",
+      "version": "1.0.0-beta.49",
       "dependencies": {
         "date-fns": "^2.23.0",
         "mitt": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.48",
+  "version": "1.0.0-beta.49",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/Dropzone/Dropzone.mdx
+++ b/src/components/Dropzone/Dropzone.mdx
@@ -24,7 +24,7 @@ All text shown in the Dropzone must be added as the `textContent` prop (Object).
 
 The required keys for the `textContent` are: `dragAndDropHere`, `yourFile`, `or`, `uploadFileButtonText`,
 `acceptedFormatIs`, `acceptedFormatsAre`, `maxFileSizeIs`, `downloadSampleFile`,
-`uploading`, `mightTakeAMinute`, `looksGreat`, `removeFileButtonText`,
+`uploading`, `mightTakeAMinute`, `looksGreat`, `removeFileButtonText`, `fileFor`,
 `couldNotUpload`, `canOnlySelectOneFile`, `fileIsTooLarge`, `fileTypeNotValid`,
 `defaultErrorText`, `errorMessage`, `successMessage`
 

--- a/src/components/Dropzone/Dropzone.stories.js
+++ b/src/components/Dropzone/Dropzone.stories.js
@@ -55,7 +55,8 @@ const textContentObject = {
   looksGreat: 'Looks great!',
   uploading: 'Uploading',
   canOnlySelectOneFile: 'You can only select 1 file.',
-  fileIsTooLarge: 'File is too large.',
+  fileFor: 'Audience',
+  fileIsTooLarge: ' exceeds file size limit of ',
   fileTypeNotValid: 'File is not a valid file type.',
   dragAndDropHere: 'Drag and drop files here',
   mightTakeAMinute: 'This might take a minute.',
@@ -68,7 +69,7 @@ const Template = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { Dropzone },
   setup: () => ({ args }),
-  data: () => ({ fileUploadStatus: args.status, file: null, textContentObject }),
+  data: () => ({ fileUploadStatus: args.status, selectedFile: null, textContentObject }),
   methods: {
     uploadAudienceFile () {
       setTimeout(() => {
@@ -76,20 +77,20 @@ const Template = (args, { argTypes }) => ({
       }, 2000);
     },
     removeAudienceFile () {
-      this.file = null;
+      this.selectedFile = null;
       this.fileUploadStatus = null;
     }
   },
   template: `
     <div style="width: 700px">
         <Dropzone
-            upload-id="dropzone"
+            input-id="dropzone"
             :accept-type="args.acceptType"
             :max-size-in-bytes="Number(args.maxSizeInBytes)"
             :show-type-and-max-size="args.showTypeAndMaxSize"
             :sample-link-url="args.sampleLinkUrl"
             :status="fileUploadStatus"
-            :file="file"
+            :file="selectedFile"
             :text-content="textContentObject"
             @select="uploadAudienceFile"
             @remove="removeAudienceFile"

--- a/src/components/Dropzone/Dropzone.stories.js
+++ b/src/components/Dropzone/Dropzone.stories.js
@@ -56,7 +56,7 @@ const textContentObject = {
   uploading: 'Uploading',
   canOnlySelectOneFile: 'You can only select 1 file.',
   fileFor: 'Audience',
-  fileIsTooLarge: ' exceeds file size limit of ',
+  fileIsTooLarge: 'exceeds file size limit of',
   fileTypeNotValid: 'File is not a valid file type.',
   dragAndDropHere: 'Drag and drop files here',
   mightTakeAMinute: 'This might take a minute.',

--- a/src/components/Dropzone/Dropzone.vue
+++ b/src/components/Dropzone/Dropzone.vue
@@ -135,7 +135,7 @@ export default {
       validator: function (value) {
         const requiredKeys = ['dragAndDropHere', 'yourFile', 'or', 'uploadFileButtonText',
           'acceptedFormatIs', 'acceptedFormatsAre', 'maxFileSizeIs', 'downloadSampleFile',
-          'uploading', 'mightTakeAMinute', 'looksGreat', 'removeFileButtonText',
+          'uploading', 'mightTakeAMinute', 'looksGreat', 'removeFileButtonText', 'fileFor',
           'couldNotUpload', 'canOnlySelectOneFile', 'fileIsTooLarge', 'fileTypeNotValid',
           'defaultErrorText', 'errorMessage', 'successMessage'];
         return requiredKeys.every((key) => value.hasOwnProperty(key));
@@ -216,7 +216,7 @@ export default {
           return this.textContent.canOnlySelectOneFile;
         }
         if (this.fileSizeError) {
-          return this.textContent.fileIsTooLarge;
+          return `${this.textContent.fileFor} ${this.textContent.fileIsTooLarge} ${formatBytes(this.maxSizeInBytes)}`;
         }
         if (this.fileTypeError) {
           return this.textContent.fileTypeNotValid;

--- a/src/components/Dropzone/__tests__/Dropzone.spec.js
+++ b/src/components/Dropzone/__tests__/Dropzone.spec.js
@@ -17,7 +17,8 @@ const textContentObject = {
   looksGreat: 'Looks great!',
   uploading: 'Uploading',
   canOnlySelectOneFile: 'You can only select 1 file.',
-  fileIsTooLarge: 'File is too large.',
+  fileFor: 'Audience',
+  fileIsTooLarge: 'exceeds file size limit of',
   fileTypeNotValid: 'File is not a valid file type.',
   dragAndDropHere: 'Drag and drop files here',
   mightTakeAMinute: 'This might take a minute.',
@@ -246,7 +247,7 @@ describe('Dropzone', () => {
         }
       });
 
-      const tooLarge = await findByText('File is too large.');
+      const tooLarge = await findByText('Audience exceeds file size limit of 1MB');
       expect(tooLarge).toBeInTheDocument();
     });
 


### PR DESCRIPTION
## JIRA

part 1b of [DANG-1448](https://lobsters.atlassian.net/browse/DANG-1448) new Dropzone component

## Description

I had started working on the Dropzone before this updated on the Dashboard (so I missed it): 
The fileSizeError has changed from 'File is too large' to '{fileFor} exceeds file size limit of {maxFileSize}'

- add `fileFor` prop
- update computed string for `fileSizeError`
- in Story: update missed `ipnut-id`, rename `file` data to `selectedFile` to avoid warning duplicate from prop

no visual changes other than the file size error message