### PR TITLE
Fix the size of the Radiobutton dot for when checked and disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.0.0-beta.51
+
+### Bug fixes
+
+Fix the size of the `Radiobutton` dot for the case of the radio button being checked and disabled
+
 ## 1.0.0-beta.50
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.50",
+  "version": "1.0.0-beta.51",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "1.0.0-beta.50",
+      "version": "1.0.0-beta.51",
       "dependencies": {
         "date-fns": "^2.23.0",
         "mitt": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.50",
+  "version": "1.0.0-beta.51",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/RadioButton/RadioButton.vue
+++ b/src/components/RadioButton/RadioButton.vue
@@ -201,8 +201,8 @@ input {
 
   &:checked:disabled + label::after {
     @apply bg-gray-100;
-    @apply h-2.5;
-    @apply w-2.5;
+    @apply h-2;
+    @apply w-2;
     @apply top-[7px];
   }
 


### PR DESCRIPTION

## Description

we likely missed this when remodelling the radiobuttons during the live sessions with Tim; we'd updated the other cases but not the `:checked:disabled` one

**before:**
<img width="245" alt="Screen Shot 2022-08-12 at 3 50 17 PM" src="https://user-images.githubusercontent.com/50080618/184432926-327d079d-fcdf-49b1-b445-1d777cea2a99.png">

**after:**
<img width="245" alt="Screen Shot 2022-08-12 at 3 49 50 PM" src="https://user-images.githubusercontent.com/50080618/184432935-ee9fc2de-ac69-450e-b342-b0128b154eca.png">
