### PR TITLE
Dang 1477/more megabutton adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.0.0-beta.54
+
+### Features
+
+Added lowerImage prop to `MegaButton`
+
 ## 1.0.0-beta.53
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.53",
+  "version": "1.0.0-beta.54",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "1.0.0-beta.53",
+      "version": "1.0.0-beta.54",
       "dependencies": {
         "date-fns": "^2.23.0",
         "mitt": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.53",
+  "version": "1.0.0-beta.54",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/MegaButton/MegaButton.vue
+++ b/src/components/MegaButton/MegaButton.vue
@@ -41,7 +41,7 @@
           data-testId="imageContainer"
           :class="[
             'mx-4 my-6',
-            {'!m-0 px-4 py-6 bg-white-100 rounded-t-lg' : twoTone},
+            {'!m-0 px-4 py-6 bg-white-100 rounded-t-lg h-32' : twoTone},
             {'!pb-0' : twoTone && lowerImage}
           ]"
         >
@@ -53,7 +53,10 @@
             {{ disabledBanner }}
           </div>
           <img
-            class="max-h-20 mx-auto"
+            :class="[
+              'max-h-20 mx-auto',
+              {'!max-h-full' : lowerImage}
+            ]"
             :src="imageSource"
             :alt="imageAltText"
           >

--- a/src/components/MegaButton/MegaButton.vue
+++ b/src/components/MegaButton/MegaButton.vue
@@ -28,7 +28,9 @@
         { 'border-0' : twoTone }
       ]"
     >
-      <div>
+      <div
+        class="w-full"
+      >
         <div
           v-if="disabled && !disabledBanner"
           data-testId="strikethru"
@@ -39,7 +41,8 @@
           data-testId="imageContainer"
           :class="[
             'mx-4 my-6',
-            {'!m-0 px-4 pt-6 bg-white-100 rounded-t-lg' : twoTone}
+            {'!m-0 px-4 py-6 bg-white-100 rounded-t-lg' : twoTone},
+            {'!pb-0' : twoTone && lowerImage}
           ]"
         >
           <div
@@ -144,6 +147,10 @@ export default {
       default: ''
     },
     twoTone: {
+      type: Boolean,
+      default: false
+    },
+    lowerImage: {
       type: Boolean,
       default: false
     }


### PR DESCRIPTION
[FIGMA](https://www.figma.com/file/S2fDQOmDtOu3wGEYXk9o6x/Campaigns?node-id=3199%3A54642)

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

* There were some subtle nuances that I missed the first time around.  See image below:  when button is two tone, sometimes the image is flush against the white part and sometimes not. Very tricky trying to get these things to align.  Had to put a set height on the gray part.  Also, the figma shows the megabutton on step 1 being the same width - so in order to achieve that with these new buttons I'm going to have to set a width on the radio buttons, which means I had to add width full to the container in the label, otherwise the gray part was not extending all the way on the x-axis.

![Screen Shot 2022-08-19 at 3 20 04 PM](https://user-images.githubusercontent.com/78509611/185691791-7f463f6b-d53e-46e3-8356-8c18703ef549.png)
<!--

## Screenshots
- before and after screenshots for features with visual changes
-->

<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
