### PR TITLE
Dang 1478/custom envelope selection in step 3 modal updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 1.0.0-beta.55
+
+### Features
+
+Added noPadding prop to `Modal`
+Made header prop optional in `Modal`
+
 ## 1.0.0-beta.54
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.54",
+  "version": "1.0.0-beta.55",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "1.0.0-beta.54",
+      "version": "1.0.0-beta.55",
       "dependencies": {
         "date-fns": "^2.23.0",
         "mitt": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.54",
+  "version": "1.0.0-beta.55",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -14,8 +14,7 @@
         aria-describedby="modalDescription"
         :style="{'width': width}"
         :class="[
-          'relative bg-white flex flex-col overflow-y-auto shadow rounded-lg p-5 max-h-5/6',
-          {'!p-0' : noPadding}
+          'relative bg-white flex flex-col overflow-y-auto shadow rounded-lg max-h-5/6', noPadding ? 'p-0' : 'p-5'
         ]"
         @mousedown.stop
       >

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -13,7 +13,10 @@
         aria-labelledby="header"
         aria-describedby="modalDescription"
         :style="{'width': width}"
-        class="relative bg-white flex flex-col overflow-y-auto shadow rounded-lg p-5 max-h-5/6"
+        :class="[
+          'relative bg-white flex flex-col overflow-y-auto shadow rounded-lg p-5 max-h-5/6',
+          {'!p-0' : noPadding}
+        ]"
         @mousedown.stop
       >
         <header
@@ -65,11 +68,15 @@ export default {
     },
     header: {
       type: String,
-      required: true
+      default: null
     },
     closeButtonAriaLabel: {
       type: String,
       required: true
+    },
+    noPadding: {
+      type: Boolean,
+      default: false
     }
   },
   emits: ['close'],


### PR DESCRIPTION
## JIRA

* This relates to [https://lobsters.atlassian.net/browse/DANG-1478](https://lobsters.atlassian.net/browse/DANG-1478)

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

* There are some subtle changes to the custom envelope selection modal that conflict with some of our current modal defaults.

In the new envelope modal when a selection is made a gray background spans the width of the entire modal.  For this, I needed the option to remove the default padding so I added a new no-padding prop that defaults to false.

The header styling is different in size and position from our defaults, so I just made the header prop not required, this will not break anything in the dashboard and allows me to just add the heading styles as I wish in the EnvelopeModal component (in dashboard).

Here is a screenshot of what the new modal needs to look like:

![Screen Shot 2022-08-25 at 4 09 35 PM](https://user-images.githubusercontent.com/78509611/186759068-716d7a80-b8c9-43d8-be0d-de48ad40ade6.png)


<!--
## Screenshots
- before and after screenshots for features with visual changes
-->

<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
