### PR TITLE
Moved the publish job to its own workflow

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,0 +1,73 @@
+name: Lint and Test
+
+# Run this when someone pushes a branch
+on: [push]
+
+jobs:
+  # Get the versions of node and npm as defined in the package.json engines
+  get-versions:
+    runs-on: ubuntu-latest
+
+    outputs:
+      node_version: ${{ steps.node_version.outputs.prop }}
+      npm_version: ${{ steps.npm_version.outputs.prop }}
+
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Read node version from package.json
+      id: node_version
+      uses: notiz-dev/github-action-json-property@v0.1.0
+      with:
+        path: "package.json"
+        prop_path: "engines.node"
+
+    - run: |
+        echo "Node version found: ${{ steps.node_version.outputs.prop }}"
+
+    - name: Read npm version from package.json
+      id: npm_version
+      uses: notiz-dev/github-action-json-property@v0.1.0
+      with:
+        path: "package.json"
+        prop_path: "engines.npm"
+
+    - run: |
+        echo "npm version found: ${{ steps.npm_version.outputs.prop }}"
+
+  # Run lint and tests
+  run-tests:
+    runs-on: ubuntu-latest
+
+    needs: get-versions
+
+    env:
+      NODE_VERSION: ${{ needs.get-versions.outputs.node_version }}
+      NPM_VERSION: ${{ needs.get-versions.outputs.npm_version }}
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Setup node with the version defined in package.json engines.
+      - name: Use Node ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      # Setup npm with the version defined in package.json engines.
+      - name: Use npm ${{ env.NPM_VERSION }}
+        run: |
+          npm install -g npm@${{ env.NPM_VERSION }}
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Run unit tests
+        run: npm run test:ci

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -1,7 +1,9 @@
-name: Node Build / Test / Lint / Publish
+name: Test and Publish
 
-# Run this when someone pushes a branch
-on: [push]
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   # Get the versions of node and npm as defined in the package.json engines
@@ -37,7 +39,6 @@ jobs:
     - run: |
         echo "npm version found: ${{ steps.npm_version.outputs.prop }}"
 
-  # Run lint and tests
   run-tests:
     runs-on: ubuntu-latest
 
@@ -60,20 +61,16 @@ jobs:
 
       # Setup npm with the version defined in package.json engines.
       - name: Use npm ${{ env.NPM_VERSION }}
-        run: |
-          npm install -g npm@${{ env.NPM_VERSION }}
+        run: npm install -g npm@${{ env.NPM_VERSION }}
 
-      - name: Running the install, lint, and test commands with npm ${{ env.NPM_VERSION }}
-        run: |
-          npm ci --legacy-peer-deps
-          npm run lint
-          npm run test:ci
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Run unit tests
+        run: npm run test:ci
 
   # Publish package to npm
   publish:
-    # Only run when pushing to the main branch
-    if: ${{ github.ref == 'refs/heads/main' }}
-
     runs-on: ubuntu-latest
 
     needs: [get-versions, run-tests]
@@ -99,10 +96,11 @@ jobs:
         run: |
           npm install -g npm@${{ env.NPM_VERSION }}
 
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
       - name: Build the package
-        run: |
-          npm ci --legacy-peer-deps
-          npm run build
+        run: npm run build
 
       - name: Publish the package to npm
         id: publish
@@ -142,3 +140,5 @@ jobs:
               generate_release_notes: true
             });
             console.log(`Release creation result: ${relRes.status}`);
+
+


### PR DESCRIPTION
## JIRA

[DANG-1559](https://lobsters.atlassian.net/browse/DANG-1559)

## Description

This just moves the publish job to its own workflow and runs the unit tests before publish.  This just makes a more clean/clear separation of workflows that run on every push regardless of the branch versus what gets run on pushes to `main` only.