### PR TITLE
DANG-1572 / add relative wrapper to MegaButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.0.0-beta.57
+
+### Bug fixes
+
+Adds a `relative` class wrapper to the MegaButton to avoid unwanted behavior because of absolute positioning
+
 ## 1.0.0-beta.56
 
 ### Features
@@ -30,6 +36,7 @@ Added twoTone prop to `MegaButton`
 ### Features
 
 - Update the background color of the `ToolTip` from `primary-700` to `gray-900` to match the new design system.
+
 ## 1.0.0-beta.51
 
 ### Bug fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.56",
+  "version": "1.0.0-beta.57",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "1.0.0-beta.56",
+      "version": "1.0.0-beta.57",
       "dependencies": {
         "date-fns": "^2.23.0",
         "mitt": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.56",
+  "version": "1.0.0-beta.57",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/MegaButton/MegaButton.vue
+++ b/src/components/MegaButton/MegaButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="relative">
     <input
       :id="id"
       type="radio"


### PR DESCRIPTION
...to fix the unwanted scroll-up behavior in step 1 of campaigns

## JIRA

related to [DANG-1572](https://lobsters.atlassian.net/browse/DANG-1572) [Fix unwanted Step 1 scrolling](https://lobsters.atlassian.net/browse/DANG-1572?atlOrigin=eyJpIjoiZTJhY2ViNGJiZDNhNGYxOGE3OGVhYjY0ZjIxNzFlY2EiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)


## Description

We have narrowed the 'scroll up behavior' down to the `MegaButton` input having class `absolute` - but without a `relative` parent, an `absolute` element is absolute to the <html> tag / aka top of the page.

<hr>

why the scroll up appeared only the add-on buttons:
- all other `MegaButton`s on Step One are wrapped in a `SectionEditable` that has a `relative` class on it, so the section wrapper is those mega's relative parent
- no wrapper or parent section of the add-ons has any positioned class, so it is defaulting to the html being the relative parent

As a partB we will test to see if any additional classes/changes are needed in the sections of step 1.
