### PR TITLE
DANG-1559: Fix publish workflow not properly accessing environment va…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -114,10 +114,12 @@ jobs:
         if: steps.publish.outputs.type != 'none'
         uses: actions/github-script@v5
         env:
-          NEW_VERSION: ${{ steps.publish.outputs.version }}
-          OLD_VERSION: ${{ steps.publish.outputs.old-version }}
+          NEW_VERSION: '${{ steps.publish.outputs.version }}'
+          OLD_VERSION: '${{ steps.publish.outputs.old-version }}'
         with:
           script: |
+            const { OLD_VERSION, NEW_VERSION } = process.env;
+
             console.log(`Version changed: ${OLD_VERSION} => ${NEW_VERSION}`);
 
             // create the tag


### PR DESCRIPTION
…riables

## JIRA

https://lobsters.atlassian.net/browse/DANG-1559

## Description

Previously this wasn't properly accessing the environment variables in the github script step as shown here: https://github.com/actions/github-script#use-env-as-input