### PR TITLE
Update megabuttons for full width top images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Adds a `topFullImage` prop to `MegaButton`
 
 ### Breaking changes
 
-removes `twoToned` and `lowerImage` props
+Removes `twoToned` and `lowerImage` props
+
 ## 1.0.0-beta.57
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.0.0-beta.58
+
+### Features
+
+Adds a `topFullImage` prop to `MegaButton` and removes `twoToned` and `lowerImage` props
 ## 1.0.0-beta.57
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Features
 
-Adds a `topFullImage` prop to `MegaButton` and removes `twoToned` and `lowerImage` props
+Adds a `topFullImage` prop to `MegaButton`
+
+### Breaking changes
+
+removes `twoToned` and `lowerImage` props
 ## 1.0.0-beta.57
 
 ### Bug fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.57",
+  "version": "1.0.0-beta.58",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "1.0.0-beta.57",
+      "version": "1.0.0-beta.58",
       "dependencies": {
         "date-fns": "^2.23.0",
         "mitt": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.57",
+  "version": "1.0.0-beta.58",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/MegaButton/MegaButton.stories.js
+++ b/src/components/MegaButton/MegaButton.stories.js
@@ -78,8 +78,20 @@ WithImageAndSmallText.args = {
   disabled: false,
   disabledBanner: null,
   text: 'Minimum 80% fur by weight',
-  imageSource: image,
-  twoTone: true
+  imageSource: image
+};
+
+export const WithTopFullImage = Template.bind({});
+WithTopFullImage.args = {
+  name: 'cat-type',
+  id: 'floofyboi',
+  value: 'floofyboi',
+  label: 'Floofyboi',
+  disabled: false,
+  disabledBanner: null,
+  text: 'Minimum 80% fur by weight',
+  imageSource: 'https://s3.us-west-2.amazonaws.com/public.lob.com/dashboard/campaigns/card-with-enterprise-badge.png',
+  topFullImage: true
 };
 
 const megaButtonModel = '';
@@ -163,7 +175,6 @@ const GroupWithImageTemplate = (args, { argTypes }) => ({
         v-model="megaButtonModel"
         imageSource=${image}
         text="Minimum 80% fur by weight. Very very very very big boy."
-
       />
     </RadioGroup>
   </div>

--- a/src/components/MegaButton/MegaButton.vue
+++ b/src/components/MegaButton/MegaButton.vue
@@ -25,7 +25,7 @@
         { 'max-w-[240px]': smallText },
         { 'min-w-[160px] max-w-[240px]': imageSource && !smallText },
         { 'items-center': !hasDisabledBanner && !smallText },
-        { 'border-0' : twoTone }
+        {'!border-0' : topFullImage}
       ]"
     >
       <div
@@ -41,8 +41,7 @@
           data-testId="imageContainer"
           :class="[
             'mx-4 my-6',
-            {'!m-0 px-4 py-6 bg-white-100 rounded-t-lg h-32' : twoTone},
-            {'!pb-0' : twoTone && lowerImage}
+            {'!m-0' : topFullImage}
           ]"
         >
           <div
@@ -55,7 +54,7 @@
           <img
             :class="[
               'max-h-20 mx-auto',
-              {'!max-h-full' : lowerImage}
+              {'!max-h-full' : topFullImage}
             ]"
             :src="imageSource"
             :alt="imageAltText"
@@ -149,11 +148,7 @@ export default {
       type: String,
       default: ''
     },
-    twoTone: {
-      type: Boolean,
-      default: false
-    },
-    lowerImage: {
+    topFullImage: {
       type: Boolean,
       default: false
     }


### PR DESCRIPTION
## JIRA

* No ticket, this is part of disabling letter add on buttons in dashboard.

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

* I need to be able to the full top half of these megabuttons as one image because of the enterprise badges.  Doing this allowed me to get rid of the twoToned and lowerImage props.


![Screen Shot 2022-09-09 at 1 33 41 PM](https://user-images.githubusercontent.com/78509611/189410819-510d8e41-1012-4ba4-922a-444161842fda.png)


<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
