### PR TITLE
Fix megabutton border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Adds a `topFullImage` prop to `MegaButton`
 
 ### Breaking changes
 
-removes `twoToned` and `lowerImage` props
+Removes `twoToned` and `lowerImage` props
+
 ## 1.0.0-beta.57
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.0.0-beta.59
+
+### Bug fixes
+
+Fixes `MegaButton` not showing as selected when using prop `topFullImage`
+
 ## 1.0.0-beta.58
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.0.0-beta.58
+
+### Features
+
+Adds a `topFullImage` prop to `MegaButton` and removes `twoToned` and `lowerImage` props
 ## 1.0.0-beta.57
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Features
 
-Adds a `topFullImage` prop to `MegaButton` and removes `twoToned` and `lowerImage` props
+Adds a `topFullImage` prop to `MegaButton`
+
+### Breaking changes
+
+removes `twoToned` and `lowerImage` props
 ## 1.0.0-beta.57
 
 ### Bug fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.58",
+  "version": "1.0.0-beta.59",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "1.0.0-beta.58",
+      "version": "1.0.0-beta.59",
       "dependencies": {
         "date-fns": "^2.23.0",
         "mitt": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.57",
+  "version": "1.0.0-beta.58",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "1.0.0-beta.57",
+      "version": "1.0.0-beta.58",
       "dependencies": {
         "date-fns": "^2.23.0",
         "mitt": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.57",
+  "version": "1.0.0-beta.58",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.58",
+  "version": "1.0.0-beta.59",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/MegaButton/MegaButton.stories.js
+++ b/src/components/MegaButton/MegaButton.stories.js
@@ -78,8 +78,20 @@ WithImageAndSmallText.args = {
   disabled: false,
   disabledBanner: null,
   text: 'Minimum 80% fur by weight',
-  imageSource: image,
-  twoTone: true
+  imageSource: image
+};
+
+export const WithTopFullImage = Template.bind({});
+WithTopFullImage.args = {
+  name: 'cat-type',
+  id: 'floofyboi',
+  value: 'floofyboi',
+  label: 'Floofyboi',
+  disabled: false,
+  disabledBanner: null,
+  text: 'Minimum 80% fur by weight',
+  imageSource: 'https://s3.us-west-2.amazonaws.com/public.lob.com/dashboard/campaigns/card-with-enterprise-badge.png',
+  topFullImage: true
 };
 
 const megaButtonModel = '';
@@ -163,7 +175,6 @@ const GroupWithImageTemplate = (args, { argTypes }) => ({
         v-model="megaButtonModel"
         imageSource=${image}
         text="Minimum 80% fur by weight. Very very very very big boy."
-
       />
     </RadioGroup>
   </div>

--- a/src/components/MegaButton/MegaButton.vue
+++ b/src/components/MegaButton/MegaButton.vue
@@ -25,7 +25,7 @@
         { 'max-w-[240px]': smallText },
         { 'min-w-[160px] max-w-[240px]': imageSource && !smallText },
         { 'items-center': !hasDisabledBanner && !smallText },
-        {'!border-0' : topFullImage}
+        {'border-0' : topFullImage && !checked}
       ]"
     >
       <div

--- a/src/components/MegaButton/MegaButton.vue
+++ b/src/components/MegaButton/MegaButton.vue
@@ -25,7 +25,7 @@
         { 'max-w-[240px]': smallText },
         { 'min-w-[160px] max-w-[240px]': imageSource && !smallText },
         { 'items-center': !hasDisabledBanner && !smallText },
-        { 'border-0' : twoTone }
+        {'!border-0' : topFullImage}
       ]"
     >
       <div
@@ -41,8 +41,7 @@
           data-testId="imageContainer"
           :class="[
             'mx-4 my-6',
-            {'!m-0 px-4 py-6 bg-white-100 rounded-t-lg h-32' : twoTone},
-            {'!pb-0' : twoTone && lowerImage}
+            {'!m-0' : topFullImage}
           ]"
         >
           <div
@@ -55,7 +54,7 @@
           <img
             :class="[
               'max-h-20 mx-auto',
-              {'!max-h-full' : lowerImage}
+              {'!max-h-full' : topFullImage}
             ]"
             :src="imageSource"
             :alt="imageAltText"
@@ -149,11 +148,7 @@ export default {
       type: String,
       default: ''
     },
-    twoTone: {
-      type: Boolean,
-      default: false
-    },
-    lowerImage: {
+    topFullImage: {
       type: Boolean,
       default: false
     }


### PR DESCRIPTION
## Description

* I accidentally broke the border when a megabutton is selected and has the topFullImage prop with my last PR, this is the fix.


![Screen Shot 2022-09-09 at 4 32 47 PM](https://user-images.githubusercontent.com/78509611/189438394-54a892a8-8920-4be6-a5f3-8ce1ed647d6e.png)
<!--
## Screenshots
- before and after screenshots for features with visual changes
-->

<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
