### PR TITLE
DANG 1622 / add unavailable prop to megabuttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-Adds a `noInput` prop to `MegaButton`
+Adds a `unavailable` prop to `MegaButton`
 
 ## 1.0.0-beta.59
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.0.0-beta.60
+
+### Features
+
+Adds a `noInput` prop to `MegaButton`
+
 ## 1.0.0-beta.59
 
 ### Bug fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.59",
+  "version": "1.0.0-beta.60",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "1.0.0-beta.59",
+      "version": "1.0.0-beta.60",
       "dependencies": {
         "date-fns": "^2.23.0",
         "mitt": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.59",
+  "version": "1.0.0-beta.60",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/MegaButton/MegaButton.vue
+++ b/src/components/MegaButton/MegaButton.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="relative">
     <input
+      v-if="!noInput"
       :id="id"
       type="radio"
       class="absolute top-1/2 left-1/2 opacity-0 peer"
@@ -149,6 +150,10 @@ export default {
       default: ''
     },
     topFullImage: {
+      type: Boolean,
+      default: false
+    },
+    noInput: {
       type: Boolean,
       default: false
     }

--- a/src/components/MegaButton/MegaButton.vue
+++ b/src/components/MegaButton/MegaButton.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="relative">
     <input
-      v-if="!noInput"
+      v-if="!unavailable"
       :id="id"
       type="radio"
       class="absolute top-1/2 left-1/2 opacity-0 peer"
@@ -153,7 +153,7 @@ export default {
       type: Boolean,
       default: false
     },
-    noInput: {
+    unavailable: {
       type: Boolean,
       default: false
     }


### PR DESCRIPTION
## JIRA

* [https://lobsters.atlassian.net/browse/DANG-1622](https://lobsters.atlassian.net/browse/DANG-1622)

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

* This ticket relates to the buttons that will trigger the edition upgrade modal in Step 1 of campaigns.  If the user does not have access to custom envelopes or cards, they will see a button that looks identical to the current radio megabuttons, but will trigger the modal instead.  By removing the input in this situation we are able to treat it more as a button.

Also, I'm not sure why the PR title check is failing...
<!--
## Screenshots
- before and after screenshots for features with visual changes
-->

<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
