### PR TITLE
DANG-1623/Add gradient variant to badge component (for beta label)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.0.0-beta.61
+
+### Features
+
+Adds `gradient` variant to `Badge`
+
 ## 1.0.0-beta.60
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.60",
+  "version": "1.0.0-beta.61",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/Badge/Badge.stories.js
+++ b/src/components/Badge/Badge.stories.js
@@ -23,7 +23,7 @@ export default {
       }
     },
     variant: {
-      options: ['info', 'success', 'warning', 'error', 'turquoise', 'flint'],
+      options: ['info', 'success', 'warning', 'error', 'turquoise', 'flint', 'gradient'],
       control: {
         type: 'select'
       }

--- a/src/components/Badge/Badge.vue
+++ b/src/components/Badge/Badge.vue
@@ -10,6 +10,7 @@
                { 'bg-coral-100 text-error': error },
                { 'bg-turquoise-100 text-turquoise-900': turquoise },
                { 'bg-flint-100 text-gray-700': flint },
+               { 'bg-gradient-114 from-[#1876db] to-[#5748ff] hover:from-[#5748ff] hover:to-[#1876db] text-white': gradient },
                { '!py-0.5': small }
       ]"
     >
@@ -26,7 +27,7 @@ export default {
       type: String,
       default: 'info',
       validator: function (value) {
-        return ['info', 'success', 'warning', 'error', 'turquoise', 'flint'].includes(value);
+        return ['info', 'success', 'warning', 'error', 'turquoise', 'flint', 'gradient'].includes(value);
       }
     },
     shape: {
@@ -62,6 +63,9 @@ export default {
     },
     flint () {
       return this.variant === 'flint';
+    },
+    gradient () {
+      return this.variant === 'gradient';
     },
     rounded () {
       return this.shape === 'rounded';

--- a/src/components/Badge/Badge.vue
+++ b/src/components/Badge/Badge.vue
@@ -10,7 +10,7 @@
                { 'bg-coral-100 text-error': error },
                { 'bg-turquoise-100 text-turquoise-900': turquoise },
                { 'bg-flint-100 text-gray-700': flint },
-               { 'bg-gradient-114 from-[#1876db] to-[#5748ff] hover:from-[#5748ff] hover:to-[#1876db] text-white': gradient },
+               { 'bg-gradient-114 from-[#1876db] to-[#5748ff] text-white': gradient },
                { '!py-0.5': small }
       ]"
     >


### PR DESCRIPTION
## JIRA

* [https://lobsters.atlassian.net/browse/DANG-1623](https://lobsters.atlassian.net/browse/DANG-1623)

## Description

* Adds a gradient variant to the badge component so we can use it as a "beta label"

## Screenshots

![Screen Shot 2022-09-28 at 10 23 54 AM](https://user-images.githubusercontent.com/20443660/192847434-80111368-da8b-432f-b339-2743161cd8ed.png)

[Michael and Shampa said this was "good enough"](https://lob.slack.com/archives/C037J0X9PGD/p1664382310081999) in terms of matching the designs without doing too much extra work that may or may not be thrown away soon-ish.
