### PR TITLE
DANG-1731/update megabutton disabled state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 1.0.0-beta.65
+
+### Features
+
+Remove strikethru line from disabled `MegaButton`
+Add image opacity to disabled `MegaButton`
+
 ## 1.0.0-beta.64
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.64",
+  "version": "1.0.0-beta.65",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "1.0.0-beta.64",
+      "version": "1.0.0-beta.65",
       "dependencies": {
         "date-fns": "^2.29.3",
         "date-fns-holiday-us": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "1.0.0-beta.64",
+  "version": "1.0.0-beta.65",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/MegaButton/MegaButton.vue
+++ b/src/components/MegaButton/MegaButton.vue
@@ -33,11 +33,6 @@
         class="w-full"
       >
         <div
-          v-if="disabled && !disabledBanner"
-          data-testId="strikethru"
-          class="strikethru-line absolute top-0 h-full w-full"
-        />
-        <div
           v-if="imageSource"
           data-testId="imageContainer"
           :class="[
@@ -55,7 +50,8 @@
           <img
             :class="[
               'max-h-20 mx-auto',
-              {'!max-h-full' : topFullImage}
+              {'!max-h-full' : topFullImage},
+              {'opacity-60' : disabled}
             ]"
             :src="imageSource"
             :alt="imageAltText"
@@ -192,9 +188,6 @@ export default {
 </script>
 
 <style scoped lang="scss">
-.strikethru-line {
-  background: linear-gradient(to top right, rgba(255, 255, 255, 0) calc(50% - 1px), #c4c4c4, rgba(255, 255, 255, 0) calc(50% + 1px));
-}
 
 label {
   box-shadow: 0 4.32px 12.95px rgba(0, 0, 0, 0.08);

--- a/src/components/MegaButton/__tests__/MegaButton.spec.js
+++ b/src/components/MegaButton/__tests__/MegaButton.spec.js
@@ -76,20 +76,6 @@ describe('Megabutton', () => {
           expect(label).toHaveClass('peer-disabled:cursor-not-allowed');
         });
 
-        it('displays the strikethru line', () => {
-          const props = {
-            ...megatextProps,
-            disabled: true
-          };
-
-          const { getByTestId } = render(MegaButton, {
-            props
-          });
-
-          const strikethruBox = getByTestId('strikethru');
-          expect(strikethruBox).toHaveClass('strikethru-line');
-        });
-
         it('does not display a banner box', () => {
           const props = {
             ...megatextProps,


### PR DESCRIPTION
## JIRA

* [https://lobsters.atlassian.net/browse/DANG-1731](https://lobsters.atlassian.net/browse/DANG-1731)

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

* Per [this slack thread](https://lob.slack.com/archives/C037J0X9PGD/p1667244204017939), we are to remove the diagonal line and add text opacity to the disabled megabutton state
<!--
## Screenshots
- before and after screenshots for features with visual changes
-->

## Before:
<img width="251" alt="Screen Shot 2022-11-01 at 2 00 44 PM" src="https://user-images.githubusercontent.com/78509611/199305150-c409c92d-ae1b-4585-a56b-46b19010c3d9.png">

## After:
<img width="266" alt="Screen Shot 2022-11-01 at 2 00 23 PM" src="https://user-images.githubusercontent.com/78509611/199305174-97c58541-2d90-4595-ad59-357898500cbc.png">


<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
