### PR TITLE
dang-1749 / update the LoadingIndicator spinner

### DIFF
--- a/src/components/LoadingIndicator/LoadingIndicator.vue
+++ b/src/components/LoadingIndicator/LoadingIndicator.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :class="loading ? `loading-gif ${loadingClass}` : ''"
+    :class="loading ? `animate-spin loading-gif ${loadingClass}` : ''"
     aria-live="polite"
     :aria-busy="loading"
     data-testId="loading-indicator"
@@ -30,8 +30,8 @@ export default {
 
 <style lang="scss" scoped>
 .loading-gif {
-  background: #fff url(https://s3-us-west-2.amazonaws.com/public.lob.com/sites/loading-gif.svg) no-repeat center;
-  background-size: 12px 12px;
+  background: #fff url(https://s3-us-west-2.amazonaws.com/public.lob.com/sites/spinner-medium.svg) no-repeat center;
+  background-size: 24px 24px;
   width: 100%;
   height: 50px;
   margin: 0 auto;


### PR DESCRIPTION
## JIRA

[DANG-1749](https://lobsters.atlassian.net/browse/DANG-1749) component rebrand of the `LoadingIndicator` spinner

[zeplin link](https://app.zeplin.io/project/6357fb022dba82821ad857bb/screen/63644cf85879d12f23fed862)

## Description

 add new spinner svg of the medium size as default
 
 we may add the small/medium/large sizing later on (at that point we will restructure the component a little bit but for now I'm using the current setup since we're only using a default size)
 
 what changed:
 we are now using a static svg, so I added the `animate-spin` tailwind class that spins it!
 the spinner will now be a little larger (than the prev one that was too small _imo_)
 
_changelog & packages to be added when approved to merge_

**demo:**

https://user-images.githubusercontent.com/50080618/200903671-5f36bb7a-de8c-4821-8cce-073032a888e4.mov

