### PR TITLE
dang-1739 / add new color palette to components and display on Theme > Colors story

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v2.0.0-beta.3
+
+### Features
+
+Adds the new Colors Palette
+
 ## v2.0.0-beta.2
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "sass-loader": "^10.1.1",
         "stylelint": "^13.13.1",
         "stylelint-config-standard": "^22.0.0",
-        "tailwind-plugin-lob": "^1.0.3",
+        "tailwind-plugin-lob": "^1.0.4",
         "tailwindcss": "^3.0.24",
         "typescript": "~3.9.3",
         "vite": "^3.1.4",
@@ -20525,9 +20525,9 @@
       "dev": true
     },
     "node_modules/tailwind-plugin-lob": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tailwind-plugin-lob/-/tailwind-plugin-lob-1.0.3.tgz",
-      "integrity": "sha512-JpNLEDBxTy3Jr0/QRYbMQk/ak/mmCRj1IPaSjaUvoY4g72nlpLrlOwRGuP0IWc3CzUNLTPG13a+Rq5ovebwMEQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tailwind-plugin-lob/-/tailwind-plugin-lob-1.0.4.tgz",
+      "integrity": "sha512-57LcDyG+MlaskPyu9qnK+68C7sc2QGExlmHPQMslC3cHXFMoACKYhtSxp4tdjqtPKA+Rwl/FEMmRozFfTUeuqg==",
       "dev": true,
       "engines": {
         "node": ">=14.18.2"
@@ -39352,9 +39352,9 @@
       }
     },
     "tailwind-plugin-lob": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tailwind-plugin-lob/-/tailwind-plugin-lob-1.0.3.tgz",
-      "integrity": "sha512-JpNLEDBxTy3Jr0/QRYbMQk/ak/mmCRj1IPaSjaUvoY4g72nlpLrlOwRGuP0IWc3CzUNLTPG13a+Rq5ovebwMEQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tailwind-plugin-lob/-/tailwind-plugin-lob-1.0.4.tgz",
+      "integrity": "sha512-57LcDyG+MlaskPyu9qnK+68C7sc2QGExlmHPQMslC3cHXFMoACKYhtSxp4tdjqtPKA+Rwl/FEMmRozFfTUeuqg==",
       "dev": true
     },
     "tailwindcss": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "sass-loader": "^10.1.1",
         "stylelint": "^13.13.1",
         "stylelint-config-standard": "^22.0.0",
-        "tailwind-plugin-lob": "^1.0.1",
+        "tailwind-plugin-lob": "^1.0.3",
         "tailwindcss": "^3.0.24",
         "typescript": "~3.9.3",
         "vite": "^3.1.4",
@@ -20525,9 +20525,9 @@
       "dev": true
     },
     "node_modules/tailwind-plugin-lob": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tailwind-plugin-lob/-/tailwind-plugin-lob-1.0.1.tgz",
-      "integrity": "sha512-tC0STctwrm5RLYj1hiZ7hp49BB4cxcVo8F6YXt+uTlw7aBUCnjdV65DjEUhMqsb/74Xi5MJ1yftC8nUre315Bg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tailwind-plugin-lob/-/tailwind-plugin-lob-1.0.3.tgz",
+      "integrity": "sha512-JpNLEDBxTy3Jr0/QRYbMQk/ak/mmCRj1IPaSjaUvoY4g72nlpLrlOwRGuP0IWc3CzUNLTPG13a+Rq5ovebwMEQ==",
       "dev": true,
       "engines": {
         "node": ">=14.18.2"
@@ -39352,9 +39352,9 @@
       }
     },
     "tailwind-plugin-lob": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tailwind-plugin-lob/-/tailwind-plugin-lob-1.0.1.tgz",
-      "integrity": "sha512-tC0STctwrm5RLYj1hiZ7hp49BB4cxcVo8F6YXt+uTlw7aBUCnjdV65DjEUhMqsb/74Xi5MJ1yftC8nUre315Bg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tailwind-plugin-lob/-/tailwind-plugin-lob-1.0.3.tgz",
+      "integrity": "sha512-JpNLEDBxTy3Jr0/QRYbMQk/ak/mmCRj1IPaSjaUvoY4g72nlpLrlOwRGuP0IWc3CzUNLTPG13a+Rq5ovebwMEQ==",
       "dev": true
     },
     "tailwindcss": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "2.0.0-beta.2",
+      "version": "2.0.0-beta.3",
       "dependencies": {
         "date-fns": "^2.29.3",
         "date-fns-holiday-us": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "sass-loader": "^10.1.1",
     "stylelint": "^13.13.1",
     "stylelint-config-standard": "^22.0.0",
-    "tailwind-plugin-lob": "^1.0.3",
+    "tailwind-plugin-lob": "^1.0.4",
     "tailwindcss": "^3.0.24",
     "typescript": "~3.9.3",
     "vite": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "sass-loader": "^10.1.1",
     "stylelint": "^13.13.1",
     "stylelint-config-standard": "^22.0.0",
-    "tailwind-plugin-lob": "^1.0.1",
+    "tailwind-plugin-lob": "^1.0.3",
     "tailwindcss": "^3.0.24",
     "typescript": "~3.9.3",
     "vite": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,7 +4,7 @@ module.exports = {
   safelist: [
     { pattern: /text-(xl|2xl|3xl|4xl|5xl)/ },
     { pattern: /text-(black|warning|error|success|lavender|chili|papaya)/ },
-    { pattern: /text-(primary|secondary|lemon|turquoise|flint|mint|coral|gray|white)-(100|200|300|500|700|900)/ }
+    { pattern: /text-(primary|secondary|lemon|turquoise|flint|mint|coral|gray|white|coolGray|purple|blue|red|orange|yellow|green)-(50|100|200|300|400|500|600|700|800|900)/ }
   ],
   theme: {
     fontFamily: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,7 @@ module.exports = {
   content: ['./src/**/*.vue'],
   safelist: [
     { pattern: /text-(xl|2xl|3xl|4xl|5xl)/ },
-    { pattern: /text-(black|warning|error|success|lavender|chili|papaya)/ },
+    { pattern: /text-(black|white|warning|error|success|lavender|chili|papaya|paper)/ },
     { pattern: /text-(primary|secondary|lemon|turquoise|flint|mint|coral|gray|white|coolGray|purple|blue|red|orange|yellow|green)-(50|100|200|300|400|500|600|700|800|900)/ }
   ],
   theme: {


### PR DESCRIPTION
## JIRA

[DANG-1739 ](https://lobsters.atlassian.net/browse/DANG-1739)

[zeplin link for reference](https://app.zeplin.io/project/6357fb022dba82821ad857bb/screen/6357fb0b4be1e77f26f2e13f)

## Description

By adding the new palette to the tailwind plugin and updating the version here, we now have all these fab new colors available. (The old ones will be removed after the rebrand when they are no longer used anywhere)

They are all available to view on the Colors Story

[DEMO LINK HERE](https://pr-355.d11k469e311m4w.amplifyapp.com/?path=/story/theme-dev-only-colors--primary) (scroll down a bit)

_will update changelog & package when ready to go in_

## Screenshots

<img width="400" alt="Screen Shot 2022-11-09 at 1 31 39 PM" src="https://user-images.githubusercontent.com/50080618/200912966-a229a2cf-0585-4c4b-b097-4f8d349e6e1e.png"> <img width="400" alt="Screen Shot 2022-11-09 at 1 31 49 PM" src="https://user-images.githubusercontent.com/50080618/200912975-67826a67-156c-4c7c-b23c-fc73a8e4fe1c.png">

<img width="400" alt="Screen Shot 2022-11-09 at 1 31 57 PM" src="https://user-images.githubusercontent.com/50080618/200913022-016af8a9-23f2-457f-bd83-fcde94ec1c97.png"> <img width="400" alt="Screen Shot 2022-11-09 at 1 32 04 PM" src="https://user-images.githubusercontent.com/50080618/200913030-3ef6fb29-ee11-4c15-ad18-d1f8df9ddb7b.png">

<img width="400" alt="Screen Shot 2022-11-09 at 1 32 10 PM" src="https://user-images.githubusercontent.com/50080618/200913057-5f820b41-e6a1-4eb7-9f8a-d2a430c40db9.png"> <img width="400" alt="Screen Shot 2022-11-09 at 1 32 14 PM" src="https://user-images.githubusercontent.com/50080618/200913075-6cf08d2b-84e5-4a8b-80e1-b78ff681c941.png">

<img width="400" alt="Screen Shot 2022-11-09 at 1 32 20 PM" src="https://user-images.githubusercontent.com/50080618/200913108-a84f5b7f-1aa0-450b-8e74-47ef917ec24e.png"> <img width="400" alt="Screen Shot 2022-11-09 at 1 32 25 PM" src="https://user-images.githubusercontent.com/50080618/200913119-ef69789e-03be-40ab-8727-390236b6431d.png">

