### PR TITLE
Dang 1739 followup on gray disabled buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v2.0.0-beta.5
+
+### Features
+
+Updates the styles of disabled Button and button-style Link
+
 ## v2.0.0-beta.4
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "2.0.0-beta.4",
+      "version": "2.0.0-beta.5",
       "dependencies": {
         "date-fns": "^2.29.3",
         "date-fns-holiday-us": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -10,14 +10,14 @@
       { 'cursor-not-allowed': disabled },
       { 'active:scale-[.96]': !disabled && !link },
       { 'bg-gradient-114 from-[#1876db] to-[#5748ff] hover:from-[#5748ff] hover:to-[#1876db] text-white': primary && !warning && !disabled },
-      { 'text-white disabled:bg-gray-100': primary && !warning && disabled },
+      { 'text-gray-400 disabled:bg-gray-100': primary && !warning && disabled },
       { 'bg-gradient-114 from-[#db1818] to-[#ec4949] hover:from-[#ec4949] hover:to-[#db1818] text-white': primary && warning && !disabled },
-      { 'text-white disabled:!bg-coral-200': primary && warning && disabled },
+      { 'text-coral-700 disabled:!bg-coral-200': primary && warning && disabled },
       { 'bg-white text-gray-500 border-gray-500 border-2 disabled:text-gray-300 disabled:border-gray-300 disabled:hover:bg-transparent': secondary && !warning,
         'hover:bg-gray-100/[.15] active:bg-bg-gray-100/[.25] disabled:text-gray-100 disabled:border-2': secondary && !warning },
-      { 'bg-white text-chili border-2 disabled:hover:bg-transparent disabled:text-coral-200 disabled:border-2 hover:bg-chili/[.04] active:bg-chili/[.08]': secondary && warning },
-      { 'text-primary-500 hover:bg-primary-500/[.04] active:bg-primary-500/[.08] active:text-primary-700 disabled:text-gray-100 disabled:border-2 disabled:hover:bg-transparent': subtle && !warning },
-      { 'text-chili hover:bg-chili/[.04] active:bg-chili/[.08] disabled:text-coral-300 disabled:border-2 disabled:hover:bg-transparent': subtle && warning }
+      { 'bg-white text-chili border-chili border-2 disabled:hover:bg-transparent disabled:text-coral-700 disabled:border-coral-700 disabled:border-2 hover:bg-chili/[.04] active:bg-chili/[.08]': secondary && warning },
+      { 'text-primary-500 hover:bg-primary-500/[.04] active:bg-primary-500/[.08] active:text-primary-700 disabled:text-gray-300 disabled:border-2 disabled:hover:bg-transparent': subtle && !warning },
+      { 'text-chili hover:bg-chili/[.04] active:bg-chili/[.08] disabled:text-coral-700 disabled:border-coral-700 disabled:border-2 disabled:hover:bg-transparent': subtle && warning }
     ]"
     :disabled="disabled"
     @click="handleClick"

--- a/src/components/Link/Link.vue
+++ b/src/components/Link/Link.vue
@@ -19,17 +19,17 @@
         { 'px-6 text-base h-[48px]': regular && (primary || secondary || subtle) },
         { 'px-4 text-sm h-[32px]': small && (primary || secondary || subtle) },
         { 'bg-gradient-114 from-[#1876db] to-[#5748ff] hover:from-[#5748ff] hover:to-[#1876db] !text-white': !disabled && primary && !warning },
-        { 'bg-gray-100 !text-white': disabled && primary && !warning },
+        { 'text-gray-400 bg-gray-100': disabled && primary && !warning },
         { 'bg-gradient-114 from-[#db1818] to-[#ec4949] hover:from-[#ec4949] hover:to-[#db1818] !text-white': !disabled && primary && warning },
-        { 'bg-coral-200 !text-white': disabled && primary && warning },
+        { 'text-coral-700 bg-coral-200': disabled && primary && warning },
         { 'border-2 !border-gray-500 text-gray-500 hover:text-gray-500 hover:bg-gray-100/[.15] active:bg-gray-100/[.25]': !disabled && secondary && !warning },
-        { 'text-gray-300 border-2': disabled && secondary && !warning },
+        { 'text-gray-300 border-gray-300 border-2': disabled && secondary && !warning },
         { 'bg-white border-2 !border-chili text-chili hover:bg-chili/[.04] active:bg-chili/[.08]': !disabled && secondary && warning },
-        { 'text-coral-200 border-2': disabled && secondary && warning },
+        { 'text-coral-700 border-coral-700 border-2': disabled && secondary && warning },
         { 'text-primary-500 hover:bg-primary-500/[.04] active:bg-primary-500/[.08] active:text-primary-700': !disabled && subtle && !warning },
-        { 'text-gray-100 border-2 hover:bg-transparent': disabled && subtle && !warning },
+        { 'text-gray-300 border-gray-300 border-2 hover:bg-transparent': disabled && subtle && !warning },
         { 'text-chili hover:bg-chili/[.04] active:bg-chili/[.08]' : !disabled && subtle && warning },
-        { 'text-coral-300 border-2 hover:bg-transparent' : disabled && subtle && warning }
+        { 'text-coral-700 border-coral-700 border-2 hover:bg-transparent' : disabled && subtle && warning }
       ]"
       v-bind="$attrs"
     >


### PR DESCRIPTION
## JIRA

Dang 1739 followup on gray disabled buttons

## Description

After the change of the gray color I missed that disabled `Button`s looked faint as well
<img width="237" alt="Screen Shot 2022-11-11 at 8 42 36 AM" src="https://user-images.githubusercontent.com/50080618/201352591-83616107-4db9-46cb-b1ca-27decfbc640c.png">

Per Michael's direction, we are slightly changing the disabled states of our buttons to make them more visible
there are no designs, we did these live on a huddle

before and after screenshots for easy review:
The same changes have been applied to Links that are styled as buttons.

primary disabled
<img width="237" alt="Screen Shot 2022-11-11 at 8 42 36 AM" src="https://user-images.githubusercontent.com/50080618/201352916-2e331bc4-2b0d-4241-b55b-8143c846b6ed.png"> -> <img width="237" alt="Screen Shot 2022-11-11 at 8 45 01 AM" src="https://user-images.githubusercontent.com/50080618/201352933-f9c01485-5911-4e57-b23a-3331ccc1d04d.png">

primary warning disabled
<img width="237" alt="Screen Shot 2022-11-11 at 8 45 55 AM" src="https://user-images.githubusercontent.com/50080618/201353156-76c34057-2b8a-4cea-aded-f0f2f8e7da5f.png"> -> <img width="237" alt="Screen Shot 2022-11-11 at 8 46 24 AM" src="https://user-images.githubusercontent.com/50080618/201353165-febf9934-311e-40b0-8d38-52463bb3951f.png">


secondary disabled 
<img width="237" alt="Screen Shot 2022-11-11 at 8 47 30 AM" src="https://user-images.githubusercontent.com/50080618/201353376-73ec03b8-26e0-46ef-a563-5cf1aa4108c9.png"> -> <img width="237" alt="Screen Shot 2022-11-11 at 8 47 26 AM" src="https://user-images.githubusercontent.com/50080618/201353377-ed4dfedb-2d2a-4b28-8c57-0c4cb31a2342.png">


secondary warning disabled 
<img width="237" alt="Screen Shot 2022-11-11 at 8 48 02 AM" src="https://user-images.githubusercontent.com/50080618/201353489-4565cb37-c7a5-4d18-8831-2a5d676cef7e.png"> -> <img width="237" alt="Screen Shot 2022-11-11 at 8 48 07 AM" src="https://user-images.githubusercontent.com/50080618/201353485-5ed5fbcb-b8eb-444d-8022-987c6a2f8246.png">

subtle disabled
<img width="237" alt="Screen Shot 2022-11-11 at 8 48 56 AM" src="https://user-images.githubusercontent.com/50080618/201353663-86ed3656-6c94-4d97-81f3-7a179ac94cf6.png"> -> <img width="237" alt="Screen Shot 2022-11-11 at 8 49 01 AM" src="https://user-images.githubusercontent.com/50080618/201353661-168e7502-0a75-4463-b7e6-6d7718a8c5c6.png">


subtle warning disabled
<img width="237" alt="Screen Shot 2022-11-11 at 8 49 42 AM" src="https://user-images.githubusercontent.com/50080618/201353802-d4514c75-83f4-4265-a626-16f866170d15.png"> -> <img width="237" alt="Screen Shot 2022-11-11 at 8 49 46 AM" src="https://user-images.githubusercontent.com/50080618/201353800-a15e2243-c0b2-4b54-af55-03d9e83da1ee.png">



