### PR TITLE
dang-1753/update Checkbox component

### DIFF
--- a/src/components/Checkbox/Checkbox.stories.js
+++ b/src/components/Checkbox/Checkbox.stories.js
@@ -50,7 +50,6 @@ const GroupTemplate = (args, { argTypes }) => ({
       value="chocolate"
       :disabled="args.disabled"
       :required="args.required"
-      :error="args.error"
       :sameLine="args.sameLine"
     />
     <checkbox
@@ -60,7 +59,6 @@ const GroupTemplate = (args, { argTypes }) => ({
       value="vanilla"
       :disabled="args.disabled"
       :required="args.required"
-      :error="args.error"
       :sameLine="args.sameLine"
     />
     <checkbox
@@ -70,7 +68,6 @@ const GroupTemplate = (args, { argTypes }) => ({
       value="strawberry"
       :disabled="args.disabled"
       :required="args.required"
-      :error="args.error"
       :sameLine="args.sameLine"
     />
   </div>

--- a/src/components/Checkbox/Checkbox.vue
+++ b/src/components/Checkbox/Checkbox.vue
@@ -19,19 +19,22 @@
     <span
       style="content: '';"
       :class="[
-        'checkmark w-4 h-4 mr-1 rounded-sm border-solid border border-gray-100 -left-5 absolute top-1',
+        'checkmark w-4 h-4 mr-1 rounded-sm border-solid border border-gray-200 -left-5 absolute top-1',
         { 'bg-white-300': disabled },
-        { '!bg-gray-100': disabled && checked },
+        { '!bg-gray-200': disabled && checked },
         { 'border-error': error },
-        { 'border-primary-500 bg-primary-500': checked }
+        { 'border-black bg-black': checked && !disabled }
       ]"
       data-testId="checkmark"
     />
     <!-- eslint-disable-next-line vue/no-v-html -->
-    <span v-html="label" />
+    <span
+      :class="['ml-1 type-small-500', disabled ? 'text-gray-400' : 'text-gray-800']"
+      v-html="label"
+    />
     <span
       v-if="required"
-      class="text-sm text-error"
+      class="text-sm text-red-500"
     >
       *
     </span>
@@ -100,14 +103,13 @@ export default {
 
 <style scoped lang="scss">
 .checkbox input:focus ~ .checkmark {
-  @apply outline-none;
-  @apply ring-2;
-  @apply ring-primary-100;
-  @apply border-transparent;
+  @apply outline-dashed;
+  @apply outline-black;
+  @apply outline-offset-1;
 }
 
 .checkbox:hover input:not(:disabled) ~ .checkmark {
-  @apply shadow-input;
+  @apply border-gray-300;
 }
 
 .checkmark::after {
@@ -119,10 +121,10 @@ export default {
 
 .checkbox .checkmark::after {
   border-width: 0 3px 3px 0;
-  top: 1px;
+  top: 1.5px;
   width: 5px;
   height: 9px;
-  left: 4px;
+  left: 4.5px;
 
   @apply border-solid;
   @apply border-white;

--- a/src/components/Checkbox/Checkbox.vue
+++ b/src/components/Checkbox/Checkbox.vue
@@ -22,7 +22,6 @@
         'checkmark w-4 h-4 mr-1 rounded-sm border-solid border border-gray-200 -left-5 absolute top-1',
         { 'bg-white-300': disabled },
         { '!bg-gray-200': disabled && checked },
-        { 'border-error': error },
         { 'border-black bg-black': checked && !disabled }
       ]"
       data-testId="checkmark"
@@ -61,10 +60,6 @@ export default {
       default: false
     },
     required: {
-      type: Boolean,
-      default: false
-    },
-    error: {
       type: Boolean,
       default: false
     },

--- a/src/components/Checkbox/Checkbox.vue
+++ b/src/components/Checkbox/Checkbox.vue
@@ -107,6 +107,11 @@ export default {
   @apply border-gray-300;
 }
 
+.checkbox:hover input:checked:not(:disabled) ~ .checkmark {
+  @apply bg-gray-700;
+  @apply border-gray-700;
+}
+
 .checkmark::after {
   content: "";
 

--- a/src/components/Checkbox/Checkbox.vue
+++ b/src/components/Checkbox/Checkbox.vue
@@ -115,10 +115,10 @@ export default {
 }
 
 .checkbox .checkmark::after {
-  border-width: 0 3px 3px 0;
-  top: 1.5px;
+  border-width: 0 2.5px 2.5px 0;
+  top: 2px;
   width: 5px;
-  height: 9px;
+  height: 8px;
   left: 4.5px;
 
   @apply border-solid;

--- a/src/components/Checkbox/__tests__/Checkbox.spec.js
+++ b/src/components/Checkbox/__tests__/Checkbox.spec.js
@@ -6,7 +6,6 @@ const initialProps = {
   modelValue: false,
   name: 'Test name',
   label: 'Test',
-  error: false,
   disabled: false
 };
 
@@ -49,18 +48,6 @@ describe('Checkbox', () => {
 
     const checkbox = getByLabelText(new RegExp(props.label));
     expect(checkbox).toBeRequired();
-  });
-
-  it('adds an error class when error prop is true', () => {
-    const props = {
-      ...initialProps,
-      error: true
-    };
-
-    const { getByTestId } = renderComponent({ props });
-
-    const checkmark = getByTestId('checkmark');
-    expect(checkmark).toHaveClass('border-error');
   });
 
   it('fires the input event when the input is clicked', async () => {


### PR DESCRIPTION
## JIRA

[DANG-1753](https://lobsters.atlassian.net/browse/DANG-1753) components rebrand: Checkbox

[zeplin link](https://app.zeplin.io/project/6357fb022dba82821ad857bb/screen/63583c45bf87b6310309365c)

## Description


Checkbox component updated per the new design - **pending design for a checked && hovered state**

 
<img width="348" alt="Screen Shot 2022-11-16 at 10 37 27 AM" src="https://user-images.githubusercontent.com/50080618/202225032-c3f2719b-b5a0-4a3a-9905-b9440e96eeca.png">

removed the `error` prop as it is not being used anywhere for a Checkbox

## Review

To review please spotcheck the checkbox states on the preview link (hover, checked, disabled etc) match the zeplin design.

**I will also get Michael's visual/design approval before merging**
