### PR TITLE
Dang-1761/search input no x when no text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v2.0.0-beta.7
+
+### Features
+
+Do not show clear buttons in `SearchBar` unless there is a search term
+
 ## v2.0.0-beta.6
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.0-beta.6",
+  "version": "2.0.0-beta.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "2.0.0-beta.6",
+      "version": "2.0.0-beta.7",
       "dependencies": {
         "date-fns": "^2.29.3",
         "date-fns-holiday-us": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.0-beta.6",
+  "version": "2.0.0-beta.7",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/SearchBar/SearchBar.vue
+++ b/src/components/SearchBar/SearchBar.vue
@@ -16,7 +16,10 @@
       </template>
       <template #iconRight>
         <button
-          class="block"
+          :class="[
+            'block opacity-0 pointer',
+            {'opacity-100 cursor-pointer' : searchTerm}
+          ]"
           :aria-label="t('search.closeLabel')"
           :disabled="disabled"
           data-testid="clearSearchButton"
@@ -150,8 +153,10 @@ export default {
       });
     },
     clearSearch () {
-      this.searchTerm = '';
-      this.searchResults = [];
+      if (this.searchTerm) {
+        this.searchTerm = '';
+        this.searchResults = [];
+      }
     },
     onClickOutside ($event) {
       if (this.$refs.searchBar) {


### PR DESCRIPTION
## JIRA

[https://lobsters.atlassian.net/browse/DANG-1761](https://lobsters.atlassian.net/browse/DANG-1761)
<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

* Don't show the clear button in the search bar unless there is currently a search term in the input.  In order to preserve the space for the clear button I changed the cursor to pointer, gave the button 0 opacity, and it does nothing if clicked when there is no search term present.  If there is a search term, it has full opacity and the click function works.
<!--
## Screenshots
- before and after screenshots for features with visual changes
-->

<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
