### PR TITLE
dang-1754/fix: LobLabel/TextInput followups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v2.0.0-beta.14
+
+### Bug fixes
+
+Refactor the `Label` component to place the Tooltip outside the label
+
 ## v2.0.0-beta.13
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.0-beta.13",
+  "version": "2.0.0-beta.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "2.0.0-beta.13",
+      "version": "2.0.0-beta.14",
       "dependencies": {
         "date-fns": "^2.29.3",
         "date-fns-holiday-us": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.0-beta.13",
+  "version": "2.0.0-beta.14",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/Label/Label.vue
+++ b/src/components/Label/Label.vue
@@ -5,6 +5,7 @@
       srOnlyLabel ? 'sr-only' : 'flex items-center mb-1 type-small-700',
       { 'justify-between flex-row-reverse': tooltipContent && (tooltipPosition === 'trailing') }
     ]"
+    data-testid="labelWrapper"
   >
     <Tooltip
       v-if="tooltipContent"

--- a/src/components/Label/Label.vue
+++ b/src/components/Label/Label.vue
@@ -1,28 +1,27 @@
 <template>
-  <span>
-    <label
-      :for="labelFor"
-      :class="[
-        readOnly ? 'text-gray-300' : 'text-gray-800',
-        srOnlyLabel ? 'sr-only' : 'flex items-center mb-1 type-small-700',
-        { 'justify-between flex-row-reverse': tooltipContent && (tooltipPosition === 'trailing') }
-      ]"
+  <span
+    :class="[
+      readOnly ? 'text-gray-300' : 'text-gray-800',
+      srOnlyLabel ? 'sr-only' : 'flex items-center mb-1 type-small-700',
+      { 'justify-between flex-row-reverse': tooltipContent && (tooltipPosition === 'trailing') }
+    ]"
+  >
+    <Tooltip
+      v-if="tooltipContent"
+      position="bottom"
+      :class="{ 'mr-1': tooltipPosition === 'leading' }"
+      :data-testid="tooltipPosition === 'trailing' ? 'tooltip-trailing' : 'tooltip-leading'"
     >
-      <Tooltip
-        v-if="tooltipContent"
-        position="bottom"
-        :class="{ 'mr-1': tooltipPosition === 'leading' }"
-        :data-testid="tooltipPosition === 'trailing' ? 'tooltip-trailing' : 'tooltip-leading'"
-      >
-        <template #trigger>
-          <CircleInfo />
-        </template>
-        <template #content>
-          <p class="w-max max-w-[200px]">
-            {{ tooltipContent }}
-          </p>
-        </template>
-      </Tooltip>
+      <template #trigger>
+        <CircleInfo />
+      </template>
+      <template #content>
+        <p class="w-max max-w-[200px]">
+          {{ tooltipContent }}
+        </p>
+      </template>
+    </Tooltip>
+    <label :for="labelFor">
       <span>
         {{ label }}
         <span

--- a/src/components/Label/Label.vue
+++ b/src/components/Label/Label.vue
@@ -9,7 +9,7 @@
     <Tooltip
       v-if="tooltipContent"
       position="bottom"
-      :class="{ 'mr-1': tooltipPosition === 'leading' }"
+      :class="['text-gray-500', { 'mr-1': tooltipPosition === 'leading' }]"
       :data-testid="tooltipPosition === 'trailing' ? 'tooltip-trailing' : 'tooltip-leading'"
     >
       <template #trigger>

--- a/src/components/Label/Label.vue
+++ b/src/components/Label/Label.vue
@@ -5,7 +5,7 @@
       :class="[
         readOnly ? 'text-gray-300' : 'text-gray-800',
         srOnlyLabel ? 'sr-only' : 'flex items-center mb-1 type-small-700',
-        { 'justify-between flex-row-reverse': tooltipPosition === 'trailing' }
+        { 'justify-between flex-row-reverse': tooltipContent && (tooltipPosition === 'trailing') }
       ]"
     >
       <Tooltip

--- a/src/components/Label/__tests__/LobLabel.spec.js
+++ b/src/components/Label/__tests__/LobLabel.spec.js
@@ -34,22 +34,22 @@ describe('LobLabel', () => {
 
     it('the tooltip shows on the left by default', () => {
       const props = { ...initialProps, tooltipContent: 'magic tooltip' };
-      const { getByText, getByTestId } = render(LobLabel, { props });
+      const { getByTestId } = render(LobLabel, { props });
 
       const tooltip = getByTestId('tooltip-leading');
       expect(tooltip).toBeInTheDocument();
-      const label = getByText(props.label);
-      expect(label.parentElement.parentElement).not.toHaveClass('justify-between');
+      const labelWrapper = getByTestId('labelWrapper');
+      expect(labelWrapper).not.toHaveClass('justify-between');
     });
 
     it('the tooltip shows on the right if tooltipPosition:trailing is added', () => {
       const props = { ...initialProps, tooltipContent: 'magic tooltip', tooltipPosition: 'trailing' };
-      const { getByText, getByTestId } = render(LobLabel, { props });
+      const { getByTestId } = render(LobLabel, { props });
 
       const tooltip = getByTestId('tooltip-trailing');
       expect(tooltip).toBeInTheDocument();
-      const label = getByText(props.label);
-      expect(label.parentElement.parentElement).toHaveClass('justify-between flex-row-reverse');
+      const labelWrapper = getByTestId('labelWrapper');
+      expect(labelWrapper).toHaveClass('justify-between flex-row-reverse');
     });
 
   });

--- a/src/components/Label/__tests__/LobLabel.spec.js
+++ b/src/components/Label/__tests__/LobLabel.spec.js
@@ -39,7 +39,7 @@ describe('LobLabel', () => {
       const tooltip = getByTestId('tooltip-leading');
       expect(tooltip).toBeInTheDocument();
       const label = getByText(props.label);
-      expect(label.parentElement).not.toHaveClass('justify-between');
+      expect(label.parentElement.parentElement).not.toHaveClass('justify-between');
     });
 
     it('the tooltip shows on the right if tooltipPosition:trailing is added', () => {
@@ -49,7 +49,7 @@ describe('LobLabel', () => {
       const tooltip = getByTestId('tooltip-trailing');
       expect(tooltip).toBeInTheDocument();
       const label = getByText(props.label);
-      expect(label.parentElement).toHaveClass('justify-between flex-row-reverse');
+      expect(label.parentElement.parentElement).toHaveClass('justify-between flex-row-reverse');
     });
 
   });

--- a/src/components/TextInput/TextInput.stories.js
+++ b/src/components/TextInput/TextInput.stories.js
@@ -1,9 +1,6 @@
 import TextInput from './TextInput.vue';
 import mdx from './TextInput.mdx';
-
-import LobLabel from '@/components/Label/Label.vue';
-import Tooltip from '@/components/Tooltip/Tooltip.vue';
-import { MagnifyingGlass, Info, Upload } from '@/components/Icons';
+import { MagnifyingGlass, Upload } from '@/components/Icons';
 
 export default {
   title: 'Components/Text Input',
@@ -93,36 +90,12 @@ IconRight.args = {
   placeholder: 'Your name here'
 };
 
-const WithTooltipTemplate = (args, { argTypes }) => ({
-  props: Object.keys(argTypes),
-  components: { TextInput, LobLabel, Info, Tooltip },
-  setup: () => ({ args }),
-  data: () => ({ textInputVModel }),
-  template: `
-    <LobLabel
-      label="Favorite Lunar Maria"
-      labelFor="one"
-      tooltipContent="This is a tooltip"
-    >
-      <template v-slot:tooltip>
-        <Tooltip>
-          <template #trigger>
-            <Info />
-          </template>
-          <template #content>
-            Moon
-          </template>      
-        </Tooltip>
-      </template>
-    </LobLabel>
-    <text-input v-bind="args" v-model="textInputVModel" />
-  `
-});
-
-export const WithTooltip = WithTooltipTemplate.bind({});
+export const WithTooltip = PrimaryTemplate.bind({});
 WithTooltip.args = {
   id: 'name',
-  placeholder: 'Mare Nectaris'
+  label: 'Name',
+  tooltipContent: 'Type name here',
+  tooltipPosition: 'trailing'
 };
 
 const BothIconsTemplate = (args, { argTypes }) => ({

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -1,12 +1,13 @@
 <template>
   <div :class="{ 'relative': withCopyButton }">
-    <lob-label
+    <LobLabel
       v-if="label"
       :label="label"
       :label-for="id"
       :required="required"
       :sr-only-label="srOnlyLabel"
       :tooltip-content="tooltipContent"
+      :tooltip-position="tooltipPosition"
     />
     <div
       v-if="withCopyButton"
@@ -143,6 +144,10 @@ export default {
       type: String,
       default: null
     },
+    tooltipPosition: { type: String, default: 'trailing',
+      validator: function (value) {
+        return ['leading', 'trailing'].includes(value);
+      } },
     modelValue: {
       type: [String, Number],
       default: null

--- a/src/components/TextInput/__tests__/TextInput.spec.js
+++ b/src/components/TextInput/__tests__/TextInput.spec.js
@@ -163,7 +163,7 @@ describe('Text input', () => {
       tooltipPosition: 'leading'
     };
 
-    it('the input can be selected by getByLabelText when the tooltip is trailing', async () => {
+    it('the label is correctly associated with the input when the tooltip is trailing', async () => {
       const { getByLabelText, getByTestId } = render(TextInput, { props: propsTooltip });
       const companyInput = getByLabelText(propsTooltip.label);
       expect(companyInput).toBeInTheDocument();
@@ -173,7 +173,7 @@ describe('Text input', () => {
       expect(tooltipTrailing).toBeInTheDocument();
     });
 
-    it('the input can be selected by getByLabelText when the tooltip is leading', () => {
+    it('the label is correctly associated with the input when the tooltip is leading', () => {
       const { getByLabelText, getByTestId } = render(TextInput, { props: propsTooltipLeading });
       const companyInput = getByLabelText(propsTooltip.label);
       expect(companyInput).toBeInTheDocument();

--- a/src/components/TextInput/__tests__/TextInput.spec.js
+++ b/src/components/TextInput/__tests__/TextInput.spec.js
@@ -150,6 +150,39 @@ describe('Text input', () => {
     expect(textInput.value).toBe('');
   });
 
+  describe('with tooltip', () => {
+
+    const propsTooltip = {
+      ...initialProps,
+      label: 'company',
+      tooltipContent: 'enter your company'
+    };
+
+    const propsTooltipLeading = {
+      ...propsTooltip,
+      tooltipPosition: 'leading'
+    };
+
+    it('the input can be selected by getByLabelText when the tooltip is trailing', async () => {
+      const { getByLabelText, getByTestId } = render(TextInput, { props: propsTooltip });
+      const companyInput = getByLabelText(propsTooltip.label);
+      expect(companyInput).toBeInTheDocument();
+      await userEvent.type(companyInput, 'lob');
+      expect(companyInput).toHaveValue('lob');
+      const tooltipTrailing = getByTestId('tooltip-trailing');
+      expect(tooltipTrailing).toBeInTheDocument();
+    });
+
+    it('the input can be selected by getByLabelText when the tooltip is leading', () => {
+      const { getByLabelText, getByTestId } = render(TextInput, { props: propsTooltipLeading });
+      const companyInput = getByLabelText(propsTooltip.label);
+      expect(companyInput).toBeInTheDocument();
+      const tooltipLeading = getByTestId('tooltip-leading');
+      expect(tooltipLeading).toBeInTheDocument();
+    });
+
+  });
+
   describe('with Copy Button', () => {
 
     let component;

--- a/src/components/Tooltip/Tooltip.vue
+++ b/src/components/Tooltip/Tooltip.vue
@@ -15,7 +15,7 @@
         <slot name="content" />
         <div
           :class="[
-            'absolute bg-transparent w-0 h-0 m-auto',
+            'absolute bg-transparent w-0 h-0 m-auto z-10',
             {
               'border-l-8 border-r-8 border-b-8 border-l-transparent border-r-transparent border-b-gray-900 -top-2': hasUpArrow
             },


### PR DESCRIPTION
## JIRA

 follow up to dang-1754 Update Label style

## Description

I realised this is needed while updating the dashboard and a bunch of Label-related tests broke. so this is needed for PR https://github.com/lob/dashboard-vue/pull/1241

- passing `tooltipPosition` through the TextInput to the Label, and making the default `trailing` (for consistency with some of our current forms - this may change in new designs)
- adding z index to the tooltip (it could cut off in some places ie within modal)
- move the tooltip outside the label so the label can be picked up by tests (findByLabelText)

