### PR TITLE
dang-1746/followup: enable iconClasses for the MainNavItam, MegaMenuItem Icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v2.0.0-beta.13
+
+### Features
+
+Add `iconClass` prop to `MegaMenuItem` & `MainNavigationItem` to adjust the icons size
+
 ## v2.0.0-beta.12
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.0-beta.12",
+  "version": "2.0.0-beta.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "2.0.0-beta.12",
+      "version": "2.0.0-beta.13",
       "dependencies": {
         "date-fns": "^2.29.3",
         "date-fns-holiday-us": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.0-beta.12",
+  "version": "2.0.0-beta.13",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/Breadcrumb/Breadcrumb.vue
+++ b/src/components/Breadcrumb/Breadcrumb.vue
@@ -4,7 +4,7 @@
       v-if="iconSrc"
       :src="iconSrc"
       :alt="iconAltText"
-      class="w-6 mr-1.5 align-bottom"
+      :class="iconClasses ? `${iconClasses}` : 'w-6 mr-1.5 align-bottom'"
     >
     <router-link
       v-for="crumb in crumbs"
@@ -44,6 +44,10 @@ export default {
     iconAltText: {
       type: String,
       default: ''
+    },
+    iconClasses: {
+      type: String,
+      default: null
     }
   },
   computed: {

--- a/src/components/MainNavigation/MainNavigationItem.vue
+++ b/src/components/MainNavigation/MainNavigationItem.vue
@@ -14,7 +14,7 @@
       <img
         :src="iconSrc"
         :alt="iconAltText"
-        class="w-6 align-bottom"
+        :class="iconClasses ? `${iconClasses}` : 'w-6 align-bottom'"
       >
       <span
         :class="[
@@ -61,6 +61,10 @@ export default {
     iconSrc: {
       type: String,
       required: true
+    },
+    iconClasses: {
+      type: String,
+      default: null
     },
     iconAltText: {
       type: String,

--- a/src/components/MegaMenu/MegaMenuItem.vue
+++ b/src/components/MegaMenu/MegaMenuItem.vue
@@ -15,8 +15,9 @@
         alt=""
         :class="[
           'self-center transition-transform duration-200 ease-linear transform hover:scale-110',
-          {'w-10 h-10': small},
-          {'w-12 h-12': !small},
+          {'w-10 h-10': small && !iconClasses},
+          {'w-12 h-12': !small && !iconClasses},
+          {[`${iconClasses}`]: iconClasses},
           // Preserves the spacing this element creates.
           {'invisible': !imageSource}]"
       >
@@ -55,6 +56,10 @@ export default {
     imageSource: {
       type: String,
       required: false,
+      default: null
+    },
+    iconClasses: {
+      type: String,
       default: null
     },
     subtitle: {


### PR DESCRIPTION
## JIRA

dang-1746 Icons followup

## Description

I was advised to also update the MainNav and TopNav Icons on the dashboard in this PR https://github.com/lob/dashboard-vue/pull/1241

This is a temporary fix until we get to update the MainNav and TopNav components to the new designs (we will then figure out how to adjust to our component icons)

- adds `iconClasses` String prop to enable width/height (or any classes) to be added to the Item Icon on the dashboard through the MainNavItem and TopNavItem components
- same for the breadcrumb flag - so it doesn't look out of place



example of Item icon without the classes, and with the `iconClasses` being added to size 20px

<img width="384" alt="Screen Shot 2022-12-09 at 1 44 10 PM" src="https://user-images.githubusercontent.com/50080618/206771431-2e129615-2b65-400e-9a9c-3bc138b20287.png"> <img width="384" alt="Screen Shot 2022-12-09 at 1 43 55 PM" src="https://user-images.githubusercontent.com/50080618/206771433-7e4bb4cf-5883-4751-a68e-64114a21f2b4.png">
