### PR TITLE
Dang-1804/MainNavigation refresh followup on icons: remove title, use aria-label on the NavItem 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v2.0.0-beta.16
+
+### Features
+
+Remove Icon titles, add aria-label for accessibility where `MainNavigationIcon` uses Icons
+
 ## v2.0.0-beta.15
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.0-beta.15",
+  "version": "2.0.0-beta.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "2.0.0-beta.15",
+      "version": "2.0.0-beta.16",
       "dependencies": {
         "date-fns": "^2.29.3",
         "date-fns-holiday-us": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.0-beta.15",
+  "version": "2.0.0-beta.16",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/Icons/AddressBook.vue
+++ b/src/components/Icons/AddressBook.vue
@@ -6,7 +6,6 @@
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title>{{ title }}</title>
     <path
       :d="path"
       fill="currentColor"
@@ -32,10 +31,6 @@ export default {
       validator: function (value) {
         return ['xxl', 'xl', 'l', 'm', 's'].includes(value);
       }
-    },
-    title: {
-      type: String,
-      default: 'Address Book Icon'
     }
   },
   computed: {

--- a/src/components/Icons/ChartMixed.vue
+++ b/src/components/Icons/ChartMixed.vue
@@ -6,7 +6,6 @@
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title>{{ title }}</title>
     <path
       :d="path"
       fill="currentColor"
@@ -32,10 +31,6 @@ export default {
       validator: function (value) {
         return ['xxl', 'xl', 'l', 'm', 's'].includes(value);
       }
-    },
-    title: {
-      type: String,
-      default: 'Chart Mixed Icon'
     }
   },
   computed: {

--- a/src/components/Icons/ChevronDown.vue
+++ b/src/components/Icons/ChevronDown.vue
@@ -6,7 +6,6 @@
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title>{{ title }}</title>
     <path
       :d="path"
       fill="currentColor"
@@ -32,10 +31,6 @@ export default {
       validator: function (value) {
         return ['xxl', 'xl', 'l', 'm', 's'].includes(value);
       }
-    },
-    title: {
-      type: String,
-      default: 'Chevron Down Icon'
     }
   },
   computed: {

--- a/src/components/Icons/CodeIcon.vue
+++ b/src/components/Icons/CodeIcon.vue
@@ -6,7 +6,6 @@
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title>{{ title }}</title>
     <path
       :d="path"
       fill="currentColor"
@@ -32,10 +31,6 @@ export default {
       validator: function (value) {
         return ['xxl', 'xl', 'l', 'm', 's'].includes(value);
       }
-    },
-    title: {
-      type: String,
-      default: 'Code Icon'
     }
   },
   computed: {

--- a/src/components/Icons/EnvelopesBulk.vue
+++ b/src/components/Icons/EnvelopesBulk.vue
@@ -6,7 +6,6 @@
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title>{{ title }}</title>
     <path
       :d="path"
       fill="currentColor"
@@ -32,10 +31,6 @@ export default {
       validator: function (value) {
         return ['xxl', 'xl', 'l', 'm', 's'].includes(value);
       }
-    },
-    title: {
-      type: String,
-      default: 'Envelopes Bulk Icon'
     }
   },
   computed: {

--- a/src/components/Icons/FileCode.vue
+++ b/src/components/Icons/FileCode.vue
@@ -6,7 +6,6 @@
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title>{{ title }}</title>
     <path
       :d="path"
       fill="currentColor"
@@ -32,10 +31,6 @@ export default {
       validator: function (value) {
         return ['xxl', 'xl', 'l', 'm', 's'].includes(value);
       }
-    },
-    title: {
-      type: String,
-      default: 'File Code Icon'
     }
   },
   computed: {

--- a/src/components/Icons/Gear.vue
+++ b/src/components/Icons/Gear.vue
@@ -6,7 +6,6 @@
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title>{{ title }}</title>
     <path
       :d="path"
       fill="currentColor"
@@ -32,10 +31,6 @@ export default {
       validator: function (value) {
         return ['xxl', 'xl', 'l', 'm', 's'].includes(value);
       }
-    },
-    title: {
-      type: String,
-      default: 'Gear Icon'
     }
   },
   computed: {

--- a/src/components/Icons/HouseChimney.vue
+++ b/src/components/Icons/HouseChimney.vue
@@ -6,7 +6,6 @@
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title>{{ title }}</title>
     <path
       :d="path"
       fill="currentColor"
@@ -32,10 +31,6 @@ export default {
       validator: function (value) {
         return ['xxl', 'xl', 'l', 'm', 's'].includes(value);
       }
-    },
-    title: {
-      type: String,
-      default: 'House Chimney Icon'
     }
   },
   computed: {

--- a/src/components/Icons/LocationDot.vue
+++ b/src/components/Icons/LocationDot.vue
@@ -6,7 +6,6 @@
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title>{{ title }}</title>
     <path
       :d="path"
       fill="currentColor"
@@ -32,10 +31,6 @@ export default {
       validator: function (value) {
         return ['xxl', 'xl', 'l', 'm', 's'].includes(value);
       }
-    },
-    title: {
-      type: String,
-      default: 'Location Dot Icon'
     }
   },
   computed: {

--- a/src/components/Icons/Webhooks.vue
+++ b/src/components/Icons/Webhooks.vue
@@ -6,7 +6,6 @@
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title>{{ title }}</title>
     <path
       :d="path"
       fill="currentColor"
@@ -32,10 +31,6 @@ export default {
       validator: function (value) {
         return ['xxl', 'xl', 'l', 'm', 's'].includes(value);
       }
-    },
-    title: {
-      type: String,
-      default: 'Webhooks Icon'
     }
   },
   computed: {

--- a/src/components/MainNavigation/MainNavigation.mdx
+++ b/src/components/MainNavigation/MainNavigation.mdx
@@ -24,7 +24,7 @@ The main navigation has a single prop, `collapsible` to control whether it has a
 
 When `collapsible` is true, the main navigation component passes information about it's expanded/collapsed state through slot props. This requires you to pass the expanded prop to the child components in the template (see example below).
 
-Icons can be added in the `#icon` slot as components. To make the icon accessible, add `role="img"` and `:title="title"` for the item title to be passed to the icon.
+Icons can be added in the `#icon` slot as components.
 
 The main navigation child items use the `#default` slot of the component.
 
@@ -35,7 +35,7 @@ Example of using this component in a template
   <template v-slot="{ expanded }">
     <main-navigation-item title="Overview" to="/overview" :expanded="expanded">
       <template #icon="{ title }">
-        <HouseChimney size="xl" role="img" :title="title" />
+        <HouseChimney size="xl" />
       </template>
     </main-navigation-item>
     <main-navigation-item
@@ -44,7 +44,7 @@ Example of using this component in a template
       :expanded="expanded"
     >
       <template #icon="{ title }">
-        <LocationDot size="xl" role="img" :title="title" />
+        <LocationDot size="xl" />
       </template>
       <main-navigation-child-item
         title="US Verifications"

--- a/src/components/MainNavigation/MainNavigation.stories.js
+++ b/src/components/MainNavigation/MainNavigation.stories.js
@@ -93,25 +93,25 @@ const Template = (args, { argTypes }) => ({
       <template v-slot="{ expanded }">
         <main-navigation-item title="Overview" to="/overview" :expanded="expanded">
           <template #icon="{ title }">
-            <HouseChimney size="xl" role="img" :title="title" />
+            <HouseChimney size="xl" />
           </template>
         </main-navigation-item>
 
         <main-navigation-item title="Mail Analytics" to="/mail-analytics" :expanded="expanded">
           <template #icon="{ title }">
-            <ChartMixed size="xl" role="img" :title="title" />
+            <ChartMixed size="xl" />
           </template>
         </main-navigation-item>
 
         <main-navigation-item title="Address Book" to="/address-book" :expanded="expanded">
           <template #icon="{ title }">
-            <AddressBook size="xl" role="img" :title="title" />
+            <AddressBook size="xl" />
           </template>
         </main-navigation-item>
 
         <main-navigation-item title="Address Verification" :expanded="expanded">
           <template #icon="{ title }">
-            <LocationDot size="xl" role="img" :title="title" />
+            <LocationDot size="xl" />
           </template>
           <main-navigation-child-item title="US Verifications" to="/us-verifications" />
           <main-navigation-child-item title="Int'l Verifications" to="/intl-verifications" />
@@ -120,7 +120,7 @@ const Template = (args, { argTypes }) => ({
 
         <main-navigation-item title="Print & Mail" :expanded="expanded">
           <template #icon="{ title }">
-            <EnvelopesBulk size="xl" role="img" :title="title" />
+            <EnvelopesBulk size="xl" />
           </template>
           <main-navigation-child-item title="Postcards" to="/postcards" />
           <main-navigation-child-item title="Letters" to="/letters" />
@@ -143,7 +143,7 @@ const ItemTemplate = (args, { argTypes }) => ({
   template: ` 
   <main-navigation-item title="Overview" to="/overview" :expanded="expanded">
     <template #icon="{ title }">
-      <HouseChimney size="xl" role="img" :title="title" />
+      <HouseChimney size="xl" />
     </template>
   </main-navigation-item>`
 });
@@ -162,7 +162,7 @@ const ItemWithChildItemsTemplate = (args, { argTypes }) => ({
   template: ` 
   <main-navigation-item title="Print & Mail" :expanded="expanded">
     <template #icon="{ title }">
-      <HouseChimney size="xl" role="img" :title="title" />
+      <HouseChimney size="xl" />
     </template>
     <main-navigation-child-item title="Postcards" to="/postcards" />
     <main-navigation-child-item title="Letters" to="/letters" />

--- a/src/components/MainNavigation/MainNavigationItem.vue
+++ b/src/components/MainNavigation/MainNavigationItem.vue
@@ -7,6 +7,7 @@
         'hover:bg-gray-50 focus:outline-none focus:ring-none focus-visible:!rounded-none focus:ring-0 focus-visible:bg-gray-50 focus-visible:!ring-0',
         [ hasActiveChild ? 'type-base-600 text-gray-800 hover:text-gray-800 active:text-gray-800' : 'type-base-500 text-gray-500 hover:text-gray-500 active:!text-gray-500' ]
       ]"
+      :aria-label="title"
       :to="to"
       :underline="false"
       active-class="!text-gray-800 !type-base-600"

--- a/src/components/MainNavigation/__tests__/MainNavigationItem.spec.js
+++ b/src/components/MainNavigation/__tests__/MainNavigationItem.spec.js
@@ -33,7 +33,7 @@ const renderComponent = async (options) => {
 
 const slots = {
   icon: `<template #icon="{ title }">
-          <HouseChimney data-testid="overview-icon" size="xl" role="img" :title="title" />
+          <HouseChimney data-testid="overview-icon" size="xl" />
         </template>`
 };
 


### PR DESCRIPTION
## JIRA

[DANG-1804](https://lobsters.atlassian.net/browse/DANG-1804) Main Navigation redesign

## Description

I run into unexpected side-effects of the icons svgs using titles, a lot of tests broke in the dashboard where Icons are used as part of inputs/buttons - they do not get picked up by `getByLabelText` etc.

So this is removing the titles in icons, and instead uses an aria-label on the MainNavigationItem which is either a link or a button, and both are read by the screen reader when the nav is collapsed.