### PR TITLE
fix the div width of the Dropdown Story

### DIFF
--- a/src/components/Dropdown/Dropdown.stories.js
+++ b/src/components/Dropdown/Dropdown.stories.js
@@ -9,7 +9,7 @@ export default {
   title: 'Components/Dropdown',
   component: Dropdown,
   decorators: [
-    () => ({ template: '<div class="w-48 mx-auto"><story /></div>' })
+    () => ({ template: '<div style="width: 250px; margin: auto;"> <story /></div>' })
   ],
   parameters: {
     docs: {


### PR DESCRIPTION
fixes the div width in the Dropdown stories

(not sure how/when this happened)

before/after
<img width="400" alt="Screen Shot 2022-12-21 at 8 54 59 AM" src="https://user-images.githubusercontent.com/50080618/208921860-04cc067e-86f6-424a-bce0-c26795df6baa.png"> <img width="400" alt="Screen Shot 2022-12-21 at 8 55 03 AM" src="https://user-images.githubusercontent.com/50080618/208921858-7d1f45e3-e1ce-4dfd-8f94-0fcc7eeddc7a.png">
