### PR TITLE
dang-1851/restyle Switch component

### DIFF
--- a/src/components/Switch/SwitchGroup.stories.js
+++ b/src/components/Switch/SwitchGroup.stories.js
@@ -35,6 +35,28 @@ Primary.args = {
   srOnlyLegend: true
 };
 
+const selectionModel = 'selection1';
+
+const TemplateWithThreeItems = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { SwitchGroup, SwitchItem },
+  data: () => ({ switchModel: selectionModel }),
+  setup: () => ({ args }),
+  template: `
+    <switch-group v-bind="args">
+      <switch-item name="mode" label="Selection 1" value="selection1" v-model="switchModel" />
+      <switch-item name="mode" label="Selection 2" value="selection2" v-model="switchModel" />
+      <switch-item name="mode" label="Selection 3" value="selection3" v-model="switchModel" />
+    </switch-group>
+  `
+});
+
+export const WithMoreOptions = TemplateWithThreeItems.bind({});
+WithMoreOptions.args = {
+  legend: 'Mode selection',
+  srOnlyLegend: true
+};
+
 const WithDisabledTemplate = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { SwitchGroup, SwitchItem },
@@ -42,8 +64,8 @@ const WithDisabledTemplate = (args, { argTypes }) => ({
   setup: () => ({ args }),
   template: `
     <switch-group v-bind="args">
-      <switch-item name="mode" label="Test" value="test" v-model="switchModel" />
-      <switch-item name="mode" label="Live" value="live" v-model="switchModel" disabled />
+      <switch-item name="mode" label="Selection 1" value="selection1" v-model="switchModel" />
+      <switch-item name="mode" label="Selection 2" value="selection2" v-model="switchModel" disabled />
     </switch-group>
   `
 });
@@ -70,7 +92,7 @@ const WithIconsTemplate = (args, { argTypes }) => ({
         value="map" 
         sr-only-label
       >
-        <Globe />
+        <Globe size="l" />
       </switch-item>
       <switch-item 
         v-model="withIconsModel" 
@@ -79,7 +101,7 @@ const WithIconsTemplate = (args, { argTypes }) => ({
         value="list" 
         sr-only-label
       >
-        <TableLayout />
+        <TableLayout size="l" />
       </switch-item>
     </switch-group>
   `

--- a/src/components/Switch/SwitchGroup.vue
+++ b/src/components/Switch/SwitchGroup.vue
@@ -1,11 +1,9 @@
 <template>
-  <fieldset
-    role="radiogroup"
-  >
+  <fieldset role="radiogroup">
     <legend :class="[{'text-sm font-normal normal-case tracking-normal text-gray-500 mb-2 border-b-0': !srOnlyLegend}, {'sr-only': srOnlyLegend}]">
       {{ legend }}
     </legend>
-    <div :class="['shadow flex flex-wrap p-1 bg-white rounded', { 'justify-center': center }]">
+    <div :class="['flex flex-wrap bg-white p-[1px] border border-gray-100 rounded-sm focus-within:outline-dotted focus-within:outline-black focus-within:outline-offset-1', { 'justify-center': center }]">
       <slot />
     </div>
   </fieldset>

--- a/src/components/Switch/SwitchItem.vue
+++ b/src/components/Switch/SwitchItem.vue
@@ -1,9 +1,10 @@
 <template>
   <div
     :class="[
-      'rounded-sm flex bg-white text-primary-500 font-thin',
-      { '!bg-primary-500 !text-white checked !font-semibold': checked },
-      { '!bg-white-300': disabled }
+      'rounded-[1px] flex type-base-600',
+      { '!bg-black checked text-white': checked },
+      { 'bg-white text-gray-500 hover:bg-gray-50 active:test-gray-600 active:bg-gray-100': !checked && !disabled },
+      { '!text-gray-300': disabled }
     ]"
   >
     <input
@@ -20,7 +21,7 @@
     <label
       :for="value"
       :class="[
-        'px-5 py-1.5 cursor-pointer',
+        'px-4 py-2 cursor-pointer',
         { 'cursor-not-allowed': disabled }
       ]"
     >


### PR DESCRIPTION
## JIRA

[DANG-1851](https://lobsters.atlassian.net/browse/DANG-1851) restyle Switch component

[Tab v2 zeplink](https://app.zeplin.io/project/6357fb022dba82821ad857bb/screen/6387b4d5d674357f49e800ab)

## Description

visual changes only

- updates the `Switch` to the new design (design of Tab v2)
- adds a Story with 3 selection items for demo

<img width="209" alt="Screen Shot 2023-01-03 at 10 02 54 AM" src="https://user-images.githubusercontent.com/50080618/210383933-ac2a4364-70ef-49db-9061-24a1a3e42515.png">
<img width="432" alt="Screen Shot 2023-01-03 at 10 05 58 AM" src="https://user-images.githubusercontent.com/50080618/210383991-d57cca63-2cdf-455a-92d7-470f60cdaf1f.png">
