### PR TITLE
dang-1752/Buttons followup - only show outline for keyboard navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v2.0.0-beta.18
+
+### Features
+
+Updates the styles of `Button` and `Link` components to only show the outline for keyboard navigation
+
 ## v2.0.0-beta.17
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.0-beta.17",
+  "version": "2.0.0-beta.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "2.0.0-beta.17",
+      "version": "2.0.0-beta.18",
       "dependencies": {
         "date-fns": "^2.29.3",
         "date-fns-holiday-us": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.0-beta.17",
+  "version": "2.0.0-beta.18",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -1,7 +1,7 @@
 <template>
   <button
     :class="[
-      'focus:outline-dashed focus:outline-black focus:outline-offset-1 whitespace-nowrap h-min',
+      'focus-visible:outline-dashed focus-visible:outline-black focus-visible:outline-offset-1 whitespace-nowrap h-min',
       link ? `${linkTypeClasses}` : 'flex justify-center items-center rounded-full',
       { 'type-xs-700 py-2 px-4 max-h-8': small && !link },
       { 'type-small-700 py-2 px-4 max-h-9': medium && !link },

--- a/src/components/FileUpload/FileUpload.vue
+++ b/src/components/FileUpload/FileUpload.vue
@@ -8,7 +8,7 @@
         { 'type-small-700 py-3 px-5 max-h-11': regular },
         { 'type-xs-700 py-2 px-4 max-h-8': small },
         'flex justify-center items-center rounded-full bg-white text-gray-800 border border-gray-800 whitespace-nowrap h-min',
-        'hover:bg-gray-50 active:bg-gray-100 focus:bg-gray-100 focus:outline-dashed focus:outline-black focus:outline-offset-1'
+        'hover:bg-gray-50 active:bg-gray-100 focus:bg-gray-100 focus-visible:outline-dashed focus-visible:outline-black focus-visible:outline-offset-1'
       ]"
       @keydown.enter="onKeydown"
       @keydown.space="onKeydown"

--- a/src/components/Link/Link.vue
+++ b/src/components/Link/Link.vue
@@ -13,7 +13,7 @@
         { [`type-${size}-600`]: isLink },
         { [`type-${size}-800 no-underline`]: isLink && bold },
         isLink ? 'text-blue-600 hover:text-blue-500' : 'flex justify-center items-center rounded-full',
-        'focus:outline-dashed focus:outline-black focus:outline-offset-1 focus:ring-0 whitespace-nowrap h-min',
+        'focus-visible:outline-dashed focus-visible:outline-black focus-visible:outline-offset-1 focus:ring-0 whitespace-nowrap h-min',
         { 'type-xs-700 py-2 px-4': isButton && size==='small' },
         { 'type-small-700 py-2 px-4': isButton && size==='base' },
         { 'type-small-700 py-3 px-5': isButton && size==='large' },

--- a/src/components/TextInput/TextInput.vue
+++ b/src/components/TextInput/TextInput.vue
@@ -112,7 +112,7 @@
       <button
         v-if="withCopyButton"
         type="button"
-        class="rounded-full px-3 h-7 type-xs-700 bg-black text-white hover:bg-gray-700 focus:outline-dashed focus:outline-black focus:outline-offset-1 active:bg-gray-800 focus:bg-gray-800"
+        class="rounded-full px-3 h-7 type-xs-700 bg-black text-white hover:bg-gray-700 focus-visible:outline-dashed focus-visible:outline-black focus-visible:outline-offset-1 active:bg-gray-800 focus:bg-gray-800"
         @click="copyToClipboard"
       >
         Copy


### PR DESCRIPTION
Per Michael's direction, the components should show the black dashed outline only when tabbing and not when clicking. 

These buttons/links are the only components that have it so far - so we just change it from `focus` to `focus-visible`

We keep this in mind for future components and I'll add the same change to the currently open PRs for the inputs.