### PR TITLE
Stop tagging me in Slack, GitHub bot (update codeowners to use dashboard group)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @bethqiang @juanfriss @mrtly @shannamurry @siddharthpant92
+*       @lob/dashboard-and-growth
 
 # Order is important; the last matching pattern takes the most
 # precedence. When someone opens a pull request that only


### PR DESCRIPTION
## JIRA

* N/A

## Description

* Updated the codeowners file to include the @lob/dashboard-and-growth group instead of using our individual GitHub usernames so that when a notification is sent to Slack, we don't get personally notified.

## GIFs/Memes

![](https://media.giphy.com/media/q8PWfM624kqpW4WWhO/giphy.gif)