### PR TITLE
Dang-1868/ loading indicator transparent bg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v2.0.0-beta.27
+
+### Features
+
+changes the `LoadingIndicator` background color to transparent
+
 ## v2.0.0-beta.26
 
 ### Bug fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.0-beta.26",
+  "version": "2.0.0-beta.27",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "2.0.0-beta.26",
+      "version": "2.0.0-beta.27",
       "dependencies": {
         "date-fns": "^2.29.3",
         "date-fns-holiday-us": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.0-beta.26",
+  "version": "2.0.0-beta.27",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/LoadingIndicator/LoadingIndicator.stories.js
+++ b/src/components/LoadingIndicator/LoadingIndicator.stories.js
@@ -20,21 +20,30 @@ const Template = (args, { argTypes }) => ({
   decorators: [() => ({ template: '<div class="block"><story /></div>' })],
   components: { LoadingIndicator },
   setup: () => ({ args }),
+  template: '<loading-indicator></loading-indicator>'
+});
+
+export const Primary = Template.bind({});
+
+const TemplateWithBackground = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  decorators: [() => ({ template: '<div class="block"><story /></div>' })],
+  components: { LoadingIndicator },
+  setup: () => ({ args }),
   template: `
   <div style="margin:auto; background-color: #f7f5fa; padding: 2em;">
-    <loading-indicator/>
+    <loading-indicator></loading-indicator>
   </div>
   `
 });
 
-export const Primary = Template.bind({});
+export const WithBackground = TemplateWithBackground.bind({});
 
 const dataPresent = false;
 
 const AfterContentLoadedTemplate = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: {  LoadingIndicator },
-  decorators: [() => ({ template: '<div class="block"><story /></div>' })],
   setup: () => ({ args }),
   data: () => ({ dataPresent }),
   mounted () {
@@ -47,12 +56,7 @@ const AfterContentLoadedTemplate = (args, { argTypes }) => ({
       }, 3000);
     }
   },
-  template:
-  `
-  <div style="margin:auto; background-color: #f7f5fa; padding: 2em;">
-  <loading-indicator><div v-if="dataPresent">Loading spinner disappeared after 3 seconds</div></loading-indicator>
-  </div>
-  `
+  template: '<loading-indicator><div v-if="dataPresent">Loading spinner disappeared after 3 seconds</div></loading-indicator>'
 });
 
 export const AfterContentLoaded = AfterContentLoadedTemplate.bind({});

--- a/src/components/LoadingIndicator/LoadingIndicator.stories.js
+++ b/src/components/LoadingIndicator/LoadingIndicator.stories.js
@@ -17,22 +17,20 @@ export default {
 
 const Template = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
-  decorators: [() => ({ template: '<div class="block"><story /></div>' })],
   components: { LoadingIndicator },
   setup: () => ({ args }),
-  template: '<loading-indicator></loading-indicator>'
+  template: '<loading-indicator/>'
 });
 
 export const Primary = Template.bind({});
 
 const TemplateWithBackground = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
-  decorators: [() => ({ template: '<div class="block"><story /></div>' })],
   components: { LoadingIndicator },
   setup: () => ({ args }),
   template: `
   <div style="margin:auto; background-color: #f7f5fa; padding: 2em;">
-    <loading-indicator></loading-indicator>
+    <loading-indicator/>
   </div>
   `
 });

--- a/src/components/LoadingIndicator/LoadingIndicator.stories.js
+++ b/src/components/LoadingIndicator/LoadingIndicator.stories.js
@@ -17,9 +17,14 @@ export default {
 
 const Template = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
-  components: {  LoadingIndicator },
+  decorators: [() => ({ template: '<div class="block"><story /></div>' })],
+  components: { LoadingIndicator },
   setup: () => ({ args }),
-  template: '<loading-indicator></loading-indicator>'
+  template: `
+  <div style="margin:auto; background-color: #f7f5fa; padding: 2em;">
+    <loading-indicator/>
+  </div>
+  `
 });
 
 export const Primary = Template.bind({});
@@ -29,6 +34,7 @@ const dataPresent = false;
 const AfterContentLoadedTemplate = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: {  LoadingIndicator },
+  decorators: [() => ({ template: '<div class="block"><story /></div>' })],
   setup: () => ({ args }),
   data: () => ({ dataPresent }),
   mounted () {
@@ -41,7 +47,12 @@ const AfterContentLoadedTemplate = (args, { argTypes }) => ({
       }, 3000);
     }
   },
-  template: '<loading-indicator><div v-if="dataPresent">Loading spinner disappeared after 3 seconds</div></loading-indicator>'
+  template:
+  `
+  <div style="margin:auto; background-color: #f7f5fa; padding: 2em;">
+  <loading-indicator><div v-if="dataPresent">Loading spinner disappeared after 3 seconds</div></loading-indicator>
+  </div>
+  `
 });
 
 export const AfterContentLoaded = AfterContentLoadedTemplate.bind({});

--- a/src/components/LoadingIndicator/LoadingIndicator.vue
+++ b/src/components/LoadingIndicator/LoadingIndicator.vue
@@ -30,7 +30,7 @@ export default {
 
 <style lang="scss" scoped>
 .loading-gif {
-  background: #fff url(https://s3.us-west-2.amazonaws.com/public.lob.com/sites/spinner-medium.svg) no-repeat center;
+  background: transparent url(https://s3.us-west-2.amazonaws.com/public.lob.com/sites/spinner-medium.svg) no-repeat center;
   background-size: 24px 24px;
   width: 100%;
   height: 50px;


### PR DESCRIPTION
## JIRA

needed for [DANG-1868](https://lobsters.atlassian.net/browse/DANG-1868) Add paper color background to dashboard views

## Description

- changes the bg color of LoadingIndicator to transparent
- adds padded and colored bg to the story to demo it

before/after:
<img width="300" alt="Screen Shot 2023-01-06 at 1 26 43 PM" src="https://user-images.githubusercontent.com/50080618/211075680-cd3dfea7-eae5-4972-8385-89b540c6c627.png"> <img width="300" alt="Screen Shot 2023-01-06 at 1 26 49 PM" src="https://user-images.githubusercontent.com/50080618/211075679-26b48e00-d71f-45e8-93d4-d6a19ad920b8.png">



[DANG-1868]: https://lobsters.atlassian.net/browse/DANG-1868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ