### PR TITLE
GC-109/add-pending-state-to-dropzone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v2.0.0-beta.34
+
+### Features
+
+Adds `uploading` as a valid value the prop `status` can have for the `Dropzone` component.
+
 ## v2.0.0-beta.33
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ While we're not strictly enforcing any particular WCAG standard (though we shoul
 - Sensical for screen reader users
 - Color contrast passes AA at least
 
+## Running storybook locally
+```bash
+npm run storybook
+```
 ## Unit testing
 ```bash
 npm run test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.0-beta.33",
+  "version": "2.0.0-beta.34",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/Dropzone/Dropzone.stories.js
+++ b/src/components/Dropzone/Dropzone.stories.js
@@ -34,7 +34,7 @@ export default {
       }
     },
     status: {
-      options: [null, 'error', 'success'],
+      options: [null, 'error', 'success', 'uploading'],
       control: {
         type: 'select'
       }

--- a/src/components/Dropzone/Dropzone.vue
+++ b/src/components/Dropzone/Dropzone.vue
@@ -148,10 +148,10 @@ export default {
     sampleLinkUrl: { type: String, default: null },
     progress: { type: [Number, null], default: null },
     file: {  type: Object, default: null },
-    status: { type: [String, null], default: null,
-      validator: function (value) {
-        return [null, 'error', 'success'].includes(value);
-      }
+    status: {
+      type: [String, null],
+      default: null,
+      validator: (value) => ([null, 'error', 'success', 'uploading'].includes(value))
     }
   },
   emits: ['select', 'remove'],
@@ -183,10 +183,10 @@ export default {
       return this.successStep && this.selectedFile;
     },
     selectedFileType () {
-      return this.selectedFile.type ? this.selectedFile.type.split('/')[1].toUpperCase() : 'File';
+      return this.selectedFile?.type?.split('/')[1].toUpperCase() || 'File';
     },
     selectedFileName () {
-      return this.selectedFile.name;
+      return this.selectedFile?.name || 'your file';
     },
     fileTypesArray () {
       const array = this.acceptType?.split(',') || [];

--- a/src/components/Dropzone/Dropzone.vue
+++ b/src/components/Dropzone/Dropzone.vue
@@ -186,7 +186,7 @@ export default {
       return this.selectedFile?.type?.split('/')[1].toUpperCase() || 'File';
     },
     selectedFileName () {
-      return this.selectedFile?.name || 'your file';
+      return this.selectedFile?.name || this.t('dropzone.yourFile');
     },
     fileTypesArray () {
       const array = this.acceptType?.split(',') || [];

--- a/src/mixins/en.js
+++ b/src/mixins/en.js
@@ -47,5 +47,8 @@ export default {
     resultsPrefix: 'View all',
     resultsSuffix: 'results...',
     noResults: 'No results found'
+  },
+  dropzone: {
+    yourFile: 'your file'
   }
 };


### PR DESCRIPTION
## JIRA

[GC-109](https://lobsters.atlassian.net/browse/GC-109)

## Description

In order to be able to work on [GC-109](https://lobsters.atlassian.net/browse/GC-109) in `dashboard-vue`, I first needed to be able to set `uploading` or `pending` as a status for the dropzone. This way, we can show the creative that was uploaded is still validating.

## Screenshots

You can test this by setting the `status` prop in the `Dropzone` story:

<img width="1009" alt="image" src="https://user-images.githubusercontent.com/83967528/218785434-e29bcc01-6fca-425f-bd87-999c34606237.png">


[GC-109]: https://lobsters.atlassian.net/browse/GC-109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GC-109]: https://lobsters.atlassian.net/browse/GC-109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ