### PR TITLE
GC-152/poof deletion warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v2.0.0-beta.35
+
+### Features
+
+Adds an optional confirm deletion modal to `Dropzone`
 ## v2.0.0-beta.34
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.0-beta.33",
+  "version": "2.0.0-beta.35",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "2.0.0-beta.33",
+      "version": "2.0.0-beta.35",
       "dependencies": {
         "date-fns": "^2.29.3",
         "date-fns-holiday-us": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.0-beta.34",
+  "version": "2.0.0-beta.35",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/Dropzone/ConfirmRemoveFileModal.vue
+++ b/src/components/Dropzone/ConfirmRemoveFileModal.vue
@@ -1,7 +1,7 @@
 <template>
   <Modal
     :visible="visible"
-    close-button-aria-label="Cancel removing file"
+    :close-button-aria-label="t('dropzone.confirmRemoveFileModal.closeButtonAriaLabel')"
     @close="$emit('close')"
   >
     <div class="px-5 flex flex-col items-center">

--- a/src/components/Dropzone/ConfirmRemoveFileModal.vue
+++ b/src/components/Dropzone/ConfirmRemoveFileModal.vue
@@ -1,0 +1,69 @@
+<template>
+  <Modal
+    :visible="visible"
+    close-button-aria-label="Cancel removing file"
+    @close="$emit('close')"
+  >
+    <div class="px-5 flex flex-col items-center">
+      <TriangleExclamation
+        size="xxl"
+        class="mb-3"
+      />
+      <div
+        class="mb-2 type-xl-600 max-w-[246px] text-center"
+      >
+        {{ title }}
+      </div>
+      <div
+        class="mb-6 type-base-400 max-w-[320px] text-center"
+      >
+        {{ subtext }}
+      </div>
+      <div class="flex w-full justify-center">
+        <LobButton
+          size="small"
+          class="mr-4"
+          @click="$emit('close')"
+        >
+          {{ t('dropzone.confirmRemoveFileModal.goBack') }}
+        </LobButton>
+        <LobButton
+          size="small"
+          variant="secondary"
+          @click="$emit('confirmClicked'); $emit('close')"
+        >
+          {{ confirmButtonText }}
+        </LobButton>
+      </div>
+    </div>
+  </Modal>
+</template>
+
+<script>
+import { Modal } from '@/components';
+import { TriangleExclamation } from '../Icons';
+import { LobButton } from '@/components';
+export default {
+  name: 'ConfirmRemoveFileModal',
+  components: { Modal, TriangleExclamation, LobButton },
+  props: {
+    visible: {
+      type: Boolean,
+      required: true
+    },
+    title: {
+      type: String,
+      default: ''
+    },
+    subtext: {
+      type: String,
+      default: ''
+    },
+    confirmButtonText: {
+      type: String,
+      default: ''
+    }
+  },
+  emits: ['close', 'confirmClicked']
+};
+</script>

--- a/src/components/Dropzone/Dropzone.stories.js
+++ b/src/components/Dropzone/Dropzone.stories.js
@@ -107,3 +107,50 @@ Primary.args = {
   status: null,
   sampleLinkUrl: 'https://www.lob.com/'
 };
+
+const WithConfirmModalTemplate = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  components: { Dropzone },
+  setup: () => ({ args }),
+  data: () => ({ fileUploadStatus: args.status, selectedFile: null, textContentObject }),
+  methods: {
+    uploadAudienceFile () {
+      setTimeout(() => {
+        this.fileUploadStatus = 'success';
+      }, 2000);
+    },
+    removeAudienceFile () {
+      this.selectedFile = null;
+      this.fileUploadStatus = null;
+    }
+  },
+  template: `
+    <div style="width: 700px">
+        <Dropzone
+            input-id="dropzone"
+            :accept-type="args.acceptType"
+            :max-size-in-bytes="Number(args.maxSizeInBytes)"
+            :show-type-and-max-size="args.showTypeAndMaxSize"
+            :sample-link-url="args.sampleLinkUrl"
+            :status="fileUploadStatus"
+            :file="selectedFile"
+            :text-content="textContentObject"
+            @select="uploadAudienceFile"
+            @remove="removeAudienceFile"
+            confirm-remove-file
+            confirm-modal-title="Are you sure?"
+            confirm-modal-subtext="Pressing continue will delete your file"
+            confirm-modal-confirm-btn-text="Continue"
+        />
+    </div>
+`
+});
+
+export const WithConfirmRemoveModal = WithConfirmModalTemplate.bind({});
+WithConfirmRemoveModal.args = {
+  acceptType: '.csv',
+  maxSizeInBytes: '2147483648',
+  showTypeAndMaxSize: true,
+  status: null,
+  sampleLinkUrl: 'https://www.lob.com/'
+};

--- a/src/components/Dropzone/Dropzone.vue
+++ b/src/components/Dropzone/Dropzone.vue
@@ -83,7 +83,7 @@
         type="reset"
         aria-label="Remove file"
         class="mt-6 underline text-gray-500 !text-sm"
-        @click.stop="removeFile"
+        @click.stop="confirmRemoveFile ? confirmRemoveFileModalVisible = true : removeFile()"
       >
         {{ textContent.removeFileButtonText }}
       </button>
@@ -120,16 +120,25 @@
         {{ textContent.downloadSampleFile }}
       </LobLink>
     </div>
+    <ConfirmRemoveFileModal
+      :visible="confirmRemoveFileModalVisible"
+      :title="confirmModalTitle"
+      :subtext="confirmModalSubtext"
+      :confirm-button-text="confirmModalConfirmBtnText"
+      @close="confirmRemoveFileModalVisible = false"
+      @confirmClicked="removeFile"
+    />
   </div>
 </template>
 
 <script>
 import { formatBytes } from '@/utils/formatBytes';
 import { LobLink, ProgressBar, Upload } from '@/components';
+import ConfirmRemoveFileModal from './ConfirmRemoveFileModal.vue';
 
 export default {
   name: 'Dropzone',
-  components: { LobLink, ProgressBar, Upload },
+  components: { LobLink, ProgressBar, Upload, ConfirmRemoveFileModal },
   props: {
     textContent: { type: Object, required: true,
       validator: function (value) {
@@ -152,7 +161,11 @@ export default {
       type: [String, null],
       default: null,
       validator: (value) => ([null, 'error', 'success', 'uploading'].includes(value))
-    }
+    },
+    confirmRemoveFile: { type: Boolean, default: false },
+    confirmModalTitle: { type: String, default: '' },
+    confirmModalSubtext: { type: String, default: '' },
+    confirmModalConfirmBtnText: { type: String, default: '' }
   },
   emits: ['select', 'remove'],
   data: function () {
@@ -163,7 +176,8 @@ export default {
       dragOverlay: false,
       multipleFilesError: false,
       fileSizeError: false,
-      fileTypeError: false
+      fileTypeError: false,
+      confirmRemoveFileModalVisible: false
     };
   },
   computed: {

--- a/src/components/Dropzone/__tests__/ConfirmRemoveFileModal.spec.js
+++ b/src/components/Dropzone/__tests__/ConfirmRemoveFileModal.spec.js
@@ -1,0 +1,47 @@
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import ConfirmRemoveFileModal from '../ConfirmRemoveFileModal.vue';
+import { translate } from '@/mixins';
+
+const mixins = [translate];
+
+const initialProps = {
+  visible: true,
+  title: 'Are you sure?',
+  subtext: 'You are about to delete your file.',
+  confirmButtonText: 'Do it!'
+};
+
+const renderComponent = (options) => render(ConfirmRemoveFileModal, { ...options, global: { mixins } });
+
+describe('ConfirmRemoveFileModal', () => {
+
+  const props = { ...initialProps };
+
+  it('displays the correct text', () => {
+    const { getByText } = renderComponent({ props });
+    const titleText = getByText(props.title);
+    const subtext = getByText(props.subtext);
+    expect(titleText).toBeInTheDocument();
+    expect(subtext).toBeInTheDocument();
+  });
+
+  it('emits the close event when go back button is clicked', async () => {
+    const { getByRole, emitted } = renderComponent({ props });
+    const goBackButton = getByRole('button', { name: 'Go Back' });
+    await userEvent.click(goBackButton);
+    const emittedEvent = emitted();
+    expect(emittedEvent).toHaveProperty('close');
+  });
+
+  it('emits the confirmClicked and close events when the confirm button is clicked', async () => {
+    const { getByRole, emitted } = renderComponent({ props });
+    const confirmButton = getByRole('button', { name: props.confirmButtonText });
+    await userEvent.click(confirmButton);
+    const emittedEvent = emitted();
+    expect(emittedEvent).toHaveProperty('confirmClicked');
+    expect(emittedEvent).toHaveProperty('close');
+  });
+
+});

--- a/src/components/Dropzone/__tests__/Dropzone.spec.js
+++ b/src/components/Dropzone/__tests__/Dropzone.spec.js
@@ -1,8 +1,11 @@
 import '@testing-library/jest-dom';
-import { render } from '@testing-library/vue';
+import { render, waitFor } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import { fireEvent } from '@testing-library/vue';
 import Dropzone from '../Dropzone.vue';
+import { translate } from '@/mixins';
+
+const mixins = [translate];
 
 const textContentObject = {
   yourFile: 'Your file',
@@ -34,7 +37,7 @@ const initialProps = {
   maxSizeInBytes: 1048576
 };
 
-const renderComponent = (options) => render(Dropzone, { ...options });
+const renderComponent = (options) => render(Dropzone, { ...options, global: { mixins } });
 
 describe('Dropzone', () => {
 
@@ -225,6 +228,40 @@ describe('Dropzone', () => {
       expect(displayText).toBeInTheDocument();
       const emittedEvent = emitted();
       expect(emittedEvent).toHaveProperty('remove');
+    });
+
+    describe('when the confirmRemoveModal props is true', () => {
+
+      const props = {
+        ...initialProps,
+        confirmRemoveFile: true,
+        confirmModalTitle: 'Are you sure?',
+        confirmModalSubtext: 'You are about to delete your file',
+        confirmModalConfirmBtnText: 'Do it!'
+      };
+
+      it('launches the confirm remove modal before removing the file', async () => {
+        const { rerender, getByText, getByRole, findByText, emitted } = renderComponent({ props });
+        await rerender({ status: 'success' });
+
+        const removeFile = getByText(textContentObject.removeFileButtonText);
+        await userEvent.click(removeFile);
+
+        const modalTitle = getByText('Are you sure?');
+        expect(modalTitle).toBeVisible();
+
+        const modalSubtext = getByText('You are about to delete your file');
+        expect(modalSubtext).toBeVisible();
+
+        const confirmButton = getByRole('button', { name: 'Do it!' });
+        await userEvent.click(confirmButton);
+
+        const displayText = await findByText(textContentObject.dragAndDropHere);
+        expect(displayText).toBeVisible();
+        const emittedEvent = emitted();
+        expect(emittedEvent).toHaveProperty('remove');
+      });
+
     });
 
   });

--- a/src/components/Dropzone/__tests__/Dropzone.spec.js
+++ b/src/components/Dropzone/__tests__/Dropzone.spec.js
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { render, waitFor } from '@testing-library/vue';
+import { render } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import { fireEvent } from '@testing-library/vue';
 import Dropzone from '../Dropzone.vue';

--- a/src/mixins/en.js
+++ b/src/mixins/en.js
@@ -49,6 +49,10 @@ export default {
     noResults: 'No results found'
   },
   dropzone: {
-    yourFile: 'your file'
+    yourFile: 'your file',
+    confirmRemoveFileModal: {
+      closeButtonAriaLabel: 'Cancel deleting file',
+      goBack: 'Go Back'
+    }
   }
 };


### PR DESCRIPTION
## JIRA

* [https://lobsters.atlassian.net/browse/GC-152](https://lobsters.atlassian.net/browse/GC-152)

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

* In campaigns we need to have a deletion confirmation modal to make sure that users do not inadvertently delete generated proofs.  Since dropzone manages its own state when it comes to removing a file an optional confirmation modal needed to be added here.

<!--
## Screenshots
- before and after screenshots for features with visual changes
-->

<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
