### PR TITLE
GC-246/radio group needs full width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v2.0.0-beta.41
+
+### Bug fixes
+
+Make `RadioGroup` full width
+
 ## v2.0.0-beta.40
 
 ### Bug fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.0-beta.40",
+  "version": "2.0.0-beta.41",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "2.0.0-beta.40",
+      "version": "2.0.0-beta.41",
       "dependencies": {
         "date-fns": "^2.29.3",
         "date-fns-holiday-us": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.0-beta.40",
+  "version": "2.0.0-beta.41",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/RadioGroup/RadioGroup.vue
+++ b/src/components/RadioGroup/RadioGroup.vue
@@ -15,7 +15,7 @@
     </legend>
     <div
       :class="[
-        'flex',
+        'flex w-full',
         {'flex-col' : separateLines}
       ]"
     >


### PR DESCRIPTION
While doing some related work I noticed a ui bug.

This PR fixes this abomination:
![Screen Shot 2023-03-23 at 5 12 48 PM](https://user-images.githubusercontent.com/78509611/227363643-31d089a9-5136-49e9-94d5-afbc4e0fa4d2.png)

After:
![Screen Shot 2023-03-23 at 5 12 56 PM](https://user-images.githubusercontent.com/78509611/227363718-5bff720f-e342-4ae1-b7fa-ddbd8a2d895d.png)
