### PR TITLE
GC-431/prevent megabutton image from overlapping border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v2.0.0-beta.42
+
+### Bug fixes
+
+Make `Megabutton` image rounded at top to prevent border overlap
+
 ## v2.0.0-beta.41
 
 ### Bug fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.0-beta.41",
+  "version": "2.0.0-beta.42",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "2.0.0-beta.41",
+      "version": "2.0.0-beta.42",
       "dependencies": {
         "date-fns": "^2.29.3",
         "date-fns-holiday-us": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.0-beta.41",
+  "version": "2.0.0-beta.42",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/MegaButton/MegaButton.vue
+++ b/src/components/MegaButton/MegaButton.vue
@@ -47,7 +47,7 @@
           </div>
           <img
             :class="[
-              'max-h-20 mx-auto',
+              'max-h-20 mx-auto rounded-t-lg',
               {'!max-h-full' : topFullImage},
               {'opacity-60' : disabled}
             ]"


### PR DESCRIPTION
## JIRA

* [A link to the JIRA ticket](https://lobsters.atlassian.net/browse/GC-431)

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

* Fixes image overlapping border on megabuttons

### Before
![Screen Shot 2023-03-27 at 4 07 15 PM](https://user-images.githubusercontent.com/78509611/228054571-41c24588-f4ef-49dd-adb0-b6960359a7ab.png)

### After
![Screen Shot 2023-03-27 at 4 03 46 PM](https://user-images.githubusercontent.com/78509611/228054625-748c0186-b5b8-4ebf-91ec-705a83883d19.png)


<!--
## Screenshots
- before and after screenshots for features with visual changes
-->

<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
