### PR TITLE
BILL-3100 Add explicit binding to currency formatter format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v2.0.0-beta.46
+
+### Bugfixes
+
+Explicitly bind `this` context of currency formatter to its parent object.
+
 ## v2.0.0-beta.45
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.0-beta.45",
+  "version": "2.0.0-beta.46",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/CurrencyInput/CurrencyInput.stories.js
+++ b/src/components/CurrencyInput/CurrencyInput.stories.js
@@ -45,7 +45,7 @@ const WithMinAndMaxTemplate = (args, { argTypes }) => ({
 });
 
 export const WithMinAndMax = WithMinAndMaxTemplate.bind({});
-Primary.args = {
+WithMinAndMax.args = {
   id: 'currency-input',
   label: 'Currency Input',
   min: 0,

--- a/src/components/CurrencyInput/currencyFormatter.js
+++ b/src/components/CurrencyInput/currencyFormatter.js
@@ -55,7 +55,7 @@ export default class CurrencyFormatter {
    * @returns {string} The formatted value.
    */
   format (value) {
-    return (value !== null && !isNaN(value)) ? this.formatter.format(value) : '';
+    return (value !== null && !isNaN(value)) ? this.formatter.format.call(this.formatter, value) : '';
   }
 
   /**


### PR DESCRIPTION
## [BILL-3100](https://lobsters.atlassian.net/browse/BILL-3100)

## Description

*Tests were failing server-side on the dashboard due to a lost this context, so this PR explicitly binds the format function to its parent.

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.


[BILL-3100]: https://lobsters.atlassian.net/browse/BILL-3100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ