### PR TITLE
GC-1373 Change TopNavDropdown to not require title prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # CHANGELOG
 
+## v2.0.0-beta.51
+
+Updates the prop definitions for `TopNavDropdown` so that `title` is no longer a required prop.
+
 ## v2.0.0-beta.50
 
 Adds the `User` and `Bell` icons to the icons library, with a props interface matching the other icons
+
 ## v2.0.0-beta.49
 
 Adds the `icon` variant to the nav dropdown.
@@ -16,6 +21,7 @@ Adds the `PuzzlePiece` icon to the icons library, with a props interface matchin
 ### Bugfixes
 
 Update `this` binding of currency formatter and input to function as expected in a NodeJS v14 environment.
+
 ## v2.0.0-beta.46
 
 ### Bugfixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.0-beta.50",
+  "version": "2.0.0-beta.51",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/TopNavDropdown/TopNavDropdown.vue
+++ b/src/components/TopNavDropdown/TopNavDropdown.vue
@@ -70,7 +70,8 @@ export default {
   components: { ChevronDown },
   props: {
     title: {
-      type: String
+      type: String,
+      default: ''
     },
     id: {
       type: String,

--- a/src/components/TopNavDropdown/TopNavDropdown.vue
+++ b/src/components/TopNavDropdown/TopNavDropdown.vue
@@ -70,8 +70,7 @@ export default {
   components: { ChevronDown },
   props: {
     title: {
-      type: String,
-      required: true
+      type: String
     },
     id: {
       type: String,


### PR DESCRIPTION
## [GC-1373](https://lobsters.atlassian.net/browse/GC-1373)

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

* Previous PR was causing console warnings because the new icon variants didn't have titles.

<!--
## Screenshots
- before and after screenshots for features with visual changes
-->

<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.


[GC-1373]: https://lobsters.atlassian.net/browse/GC-1373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ