### PR TITLE
GC-1634/design-updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v.2.0.0-beta.56
+
+Some style updates for `Modal` and `Badge`:
+- Modal: allow removing the section separators/dividers
+- Modal: allow a subheading
+- Badge: create a new variant for a new gradient
+
 ## v2.0.0-beta.55
 
 Adds the external link icon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## v.2.0.0-beta.56
+## v2.0.0-beta.56
 
 Some style updates for `Modal` and `Badge`:
 - Modal: allow removing the section separators/dividers

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.0-beta.55",
+  "version": "2.0.0-beta.56",
   "engines": {
     "node": ">=14.18.2",
     "npm": ">=8.3.0"

--- a/src/components/Badge/Badge.stories.js
+++ b/src/components/Badge/Badge.stories.js
@@ -23,7 +23,7 @@ export default {
       }
     },
     variant: {
-      options: ['default', 'secondary', 'info', 'success', 'warning', 'error', 'gradient'],
+      options: ['default', 'secondary', 'info', 'success', 'warning', 'error', 'gradient-primary', 'gradient-secondary'],
       control: {
         type: 'select'
       }

--- a/src/components/Badge/Badge.vue
+++ b/src/components/Badge/Badge.vue
@@ -9,7 +9,8 @@
                { 'bg-green-50 text-green-700': success },
                { 'bg-orange-50 text-orange-600': warning },
                { 'bg-red-50 text-red-600': error },
-               { 'bg-gradient-114 from-[#1876db] to-[#5748ff] !text-white': gradient }
+               { 'bg-gradient-114 from-[#1876db] to-[#5748ff] !text-white': gradientPrimary },
+               { 'bg-gradient-114 from-[#9F94FF] to-[#FA6A8C] !text-white': gradientSecondary }
       ]"
     >
       <slot />
@@ -24,9 +25,8 @@ export default {
     variant: {
       type: String,
       default: 'default',
-      validator: function (value) {
-        return ['default', 'secondary', 'info', 'success', 'warning', 'error', 'gradient'].includes(value);
-      }
+      validator: (value) =>
+        ['default', 'secondary', 'info', 'success', 'warning', 'error', 'gradient-primary', 'gradient-secondary'].includes(value)
     },
     size: {
       type: String,
@@ -55,8 +55,11 @@ export default {
     error () {
       return this.variant === 'error';
     },
-    gradient () {
-      return this.variant === 'gradient';
+    gradientPrimary () {
+      return this.variant === 'gradient-primary';
+    },
+    gradientSecondary () {
+      return this.variant === 'gradient-secondary';
     },
     small () {
       return this.size === 'small';

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -24,7 +24,12 @@
           :class="['pb-4', {'border-b border-gray-100': !noSectionDividers}]"
         >
           <h1 class="pageheading">{{ header }}</h1>
-          <h2 v-if="subheader" class="text-default">{{ subheader }}</h2>
+          <h2
+            v-if="subheader"
+            class="text-default"
+          >
+            {{ subheader }}
+          </h2>
         </header>
         <section
           id="modalDescription"

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -2,7 +2,7 @@
   <transition name="fade">
     <div
       v-show="visible"
-      :class="['fixed inset-0 flex items-center justify-center bg-black bg-opacity-60 z-30']"
+      class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-60 z-30"
       :aria-hidden="!visible"
       @mousedown="closeModal"
       @keydown.esc="closeModal"
@@ -14,26 +14,27 @@
         aria-describedby="modalDescription"
         :style="{'width': width}"
         :class="[
-          'relative bg-white flex flex-col overflow-y-auto shadow rounded-lg max-h-5/6', noPadding ? 'p-0' : 'p-5'
+          'relative bg-white flex flex-col overflow-y-auto shadow rounded-lg max-h-5/6', paddingClass
         ]"
         @mousedown.stop
       >
         <header
           v-if="header"
           id="header"
-          class="pageheading border-b border-gray-100 pb-4"
+          :class="['pb-4', {'border-b border-gray-100': !noSectionDividers}]"
         >
-          {{ header }}
+          <h1 class="pageheading">{{ header }}</h1>
+          <h2 v-if="subheader" class="text-default">{{ subheader }}</h2>
         </header>
         <section
           id="modalDescription"
-          :class="[noPadding ? 'py-0' : 'py-5']"
+          :class="paddingClass"
         >
           <slot />
         </section>
         <footer
           v-if="hasFooter"
-          class="flex border-t border-gray-100 flex-col pt-4"
+          :class="['flex flex-col pt-4', {'border-t border-gray-100': !noSectionDividers}]"
         >
           <slot name="footer" />
         </footer>
@@ -69,11 +70,19 @@ export default {
       type: String,
       default: null
     },
+    subheader: {
+      type: String,
+      default: null
+    },
     closeButtonAriaLabel: {
       type: String,
       required: true
     },
     noPadding: {
+      type: Boolean,
+      default: false
+    },
+    noSectionDividers: {
       type: Boolean,
       default: false
     }
@@ -82,6 +91,9 @@ export default {
   computed: {
     hasFooter () {
       return Boolean(this.$slots.footer);
+    },
+    paddingClass () {
+      return this.noPadding ? 'p-0' : 'p-7';
     }
   },
   methods: {


### PR DESCRIPTION
## JIRA

[GC-1634](https://lobsters.atlassian.net/browse/GC-1634)

## Description

In order to achieve [these Figma designs](https://www.figma.com/file/wcnyhGCMthUamrczESUzr3/Event-Based-Campaigns?type=design&node-id=2480-2764&mode=design&t=eP8Bf9iqds8HGC64-0), I needed to make some changes to the modal and badge components:

- Modal: allow removing the section separators/dividers
- Modal: allow a subheading
- Badge: create a new variant for a new gradient

<img width="727" alt="image" src="https://github.com/lob/ui-components/assets/83967528/123f3801-8e94-4f08-92ee-219b8ea37e73">

<img width="677" alt="image" src="https://github.com/lob/ui-components/assets/83967528/639e5a7e-7d9b-4693-9a66-a36325323801">


[GC-1634]: https://lobsters.atlassian.net/browse/GC-1634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ