### PR TITLE
SELF-146: Add `Modal` `iconColor`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v2.0.15
+
+- Adds `IconColor` options to the `Modal` component of
+  - `error`
+  - `info`
+  - `neutral`
+  - `success`
+  - `upgrade`
+  - `warning`
+
 ## v2.0.14
 
 - Fix `v-model` on `NumberInput`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "2.0.14",
+      "version": "2.0.15",
       "dependencies": {
         "date-fns": "^2.29.3",
         "date-fns-holiday-us": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "engines": {
     "node": ">=20.2.0",
     "npm": ">=10.2.0"

--- a/src/components/Modal/Modal.stories.js
+++ b/src/components/Modal/Modal.stories.js
@@ -5,7 +5,7 @@ import { IconName } from '../Icon/types';
 
 import Modal from './Modal.vue';
 import mdx from './Modal.mdx';
-import { ModalColor, ModalVariant } from './types';
+import { ModalColor, ModalVariant } from './constants';
 
 export default {
   title: 'Components/Modal',

--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -69,7 +69,7 @@ import { IconName } from '@/components/Icon/types';
 import Dialog, { DialogProps } from 'primevue/dialog';
 import { computed, useSlots } from 'vue';
 
-import { ModalColor, ModalVariant } from './types';
+import { ModalColor, ModalVariant } from './constants';
 
 const props = withDefaults(
   defineProps<{
@@ -124,6 +124,24 @@ const hasFooter = computed(() => Boolean(slots.footer));
     }
     &-green {
       @apply bg-green-50 text-green-600;
+    }
+    &-success {
+      @apply bg-green-50 text-green-600;
+    }
+    &-error {
+      @apply bg-red-50 text-red-500;
+    }
+    &-warning {
+      @apply bg-yellow-50 text-yellow-700;
+    }
+    &-info {
+      @apply bg-blue-50 text-blue-500;
+    }
+    &-upgrade {
+      @apply bg-purple-50 text-purple-500;
+    }
+    &-neutral {
+      @apply bg-gray-50 text-black;
     }
   }
 }

--- a/src/components/Modal/constants.ts
+++ b/src/components/Modal/constants.ts
@@ -6,7 +6,13 @@ export const ModalVariant = {
 export type ModalVariant = (typeof ModalVariant)[keyof typeof ModalVariant];
 
 export const ModalColor = {
+  ERROR: Color.ERROR,
   GREEN: Color.GREEN,
-  PRIMARY: Color.PRIMARY
+  INFO: Color.INFO,
+  NEUTRAL: Color.NEUTRAL,
+  PRIMARY: Color.PRIMARY,
+  SUCCESS: Color.SUCCESS,
+  UPGRADE: Color.UPGRADE,
+  WARNING: Color.WARNING
 } as const;
 export type ModalColor = (typeof ModalColor)[keyof typeof ModalColor];

--- a/src/types/Color.ts
+++ b/src/types/Color.ts
@@ -1,5 +1,11 @@
 export const Color = {
+  ERROR: 'error',
   GREEN: 'green',
-  PRIMARY: 'primary'
+  INFO: 'info',
+  NEUTRAL: 'neutral',
+  PRIMARY: 'primary',
+  SUCCESS: 'success',
+  UPGRADE: 'upgrade',
+  WARNING: 'warning'
 } as const;
 export type Color = (typeof Color)[keyof typeof Color];


### PR DESCRIPTION
## JIRA

- [SELF-146](https://lobsters.atlassian.net/browse/SELF-146)

## Description
- Adds some more `Modal` `iconColor`s

## Screenshots
![image](https://github.com/lob/ui-components/assets/77284592/6e870c36-e981-425c-a48e-f5df7d85e920)
![image](https://github.com/lob/ui-components/assets/77284592/0057ad42-8512-4159-8c26-4999daa2a452)
![image](https://github.com/lob/ui-components/assets/77284592/972d37e2-b5d0-440d-8d12-9fb2cc446324)
![image](https://github.com/lob/ui-components/assets/77284592/88a92e29-7c5a-45a7-aee0-3f577d921f0a)
![image](https://github.com/lob/ui-components/assets/77284592/e1b3d296-939c-4217-ab19-77b2fd4960d8)
![image](https://github.com/lob/ui-components/assets/77284592/0ea9585c-b926-4152-8c1d-4ed99c971be6)


## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.


[SELF-146]: https://lobsters.atlassian.net/browse/SELF-146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ