### PR TITLE
GC-2490 center FAB on parent element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v2.0.19
+
+- `FloatingActionButton` will now center on parent component rather than viewport
+
 ## v2.0.18
 
 - export `FloatingActionButton` component

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v2.0.18
+
+- export `FloatingActionButton` component
+
 ## v2.0.17
 
 - Add `FloatingActionButton` component

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "2.0.17",
+      "version": "2.0.18",
       "dependencies": {
         "date-fns": "^2.29.3",
         "date-fns-holiday-us": "^0.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.18",
+  "version": "2.0.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "2.0.18",
+      "version": "2.0.19",
       "dependencies": {
         "date-fns": "^2.29.3",
         "date-fns-holiday-us": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.18",
+  "version": "2.0.19",
   "engines": {
     "node": ">=20.2.0",
     "npm": ">=10.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "engines": {
     "node": ">=20.2.0",
     "npm": ">=10.2.0"

--- a/src/components/FloatingActionButton/FloatingActionButton.mdx
+++ b/src/components/FloatingActionButton/FloatingActionButton.mdx
@@ -3,8 +3,9 @@ import { Primary } from './FloatingActionButton.stories';
 
 # FloatingActionButton
 
-A floating action button (FAB) is a circular button that hovers above the user interface
-common or important action, such as creating a new item or performing a main action.
+**This component will render centered to its parent object.** It will not show in the preview due to limitations with Storybook.
+This floating action button (FAB) is a badge with an embeded button that hovers above the user interface.
+Common or important action, such as creating a new item or performing a main action.
 FABs are commonly used in material design to enhance the user experience and provide
 quick access to key functionality.
 

--- a/src/components/FloatingActionButton/FloatingActionButton.stories.js
+++ b/src/components/FloatingActionButton/FloatingActionButton.stories.js
@@ -55,11 +55,9 @@ const Template = (args, { argTypes }) => ({
   components: { FloatingActionButton },
   setup: () => ({ args }),
   template: `
-  <div style="max-height: 200px; overflow-y: auto;">
-    <div style="height: 5000px;">
-      <floating-action-button v-bind="args"></floating-action-button>
-    </div>
-  </div>
+      <div style="height: 100px; width: 100%;">
+        <floating-action-button v-bind="args"></floating-action-button>
+      </div>
 `
 });
 

--- a/src/components/FloatingActionButton/FloatingActionButton.vue
+++ b/src/components/FloatingActionButton/FloatingActionButton.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="fixed bottom-6 left-0 w-full flex justify-center">
+  <div class="fixed bottom-6 w-full flex justify-center">
     <div
-      class="p-4 flex justify-between drop-shadow-xl bg-white rounded-xl items-center border-gray-100 border"
+      class="p-4 -translate-x-1/2 flex justify-between drop-shadow-xl bg-white rounded-xl items-center border-gray-100 border"
     >
       <span class="pr-8">{{ labelText }}</span>
       <Button :variant="buttonVariant" size="medium" @click="emits('click')">

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -50,3 +50,4 @@ export { default as Stepper } from './Stepper/Stepper';
 export { default as StepperItem } from './Stepper/StepperItem';
 export { default as StepperVertical } from './StepperVertical/StepperVertical';
 export { default as Dropzone } from './Dropzone/Dropzone';
+export { default as FloatingActionButton } from './FloatingActionButton/FloatingActionButton';


### PR DESCRIPTION
## JIRA

[- A link to the JIRA ticket](https://lobsters.atlassian.net/browse/GC-2490)

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

- The FAB as it exists prior to this PR will center within the viewport. This change will make it center on the parent element

## Screenshots
- before
<img width="1318" alt="image" src="https://github.com/lob/ui-components/assets/94082162/49a925b6-764d-45f2-8deb-b88beef4bf5c">

- after
<img width="1312" alt="image" src="https://github.com/lob/ui-components/assets/94082162/fef3e517-69b9-4d84-9256-17f94b9863f1">


<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->


## Areas of Concern
- the element will not appear correctly centered in the Storybook UI. This, unfortunately, seems to be a bug. We might want to revisit the issue if we ever plan on creating horizontal positioning variants.

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
