### PR TITLE
MI-153: Add color picker component with hex color input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.29",
+  "version": "2.0.30",
   "engines": {
     "node": ">=20.2.0",
     "npm": ">=10.2.0"

--- a/src/components/ColorPicker/BaseColorPicker.vue
+++ b/src/components/ColorPicker/BaseColorPicker.vue
@@ -1,0 +1,57 @@
+<script>
+import BaseComponent from 'primevue/basecomponent';
+import ColorPickerStyle from 'primevue/colorpicker/style';
+
+export default {
+  name: 'BaseColorPicker',
+  extends: BaseComponent,
+  provide() {
+    return {
+      $parentInstance: this
+    };
+  },
+  props: {
+    modelValue: {
+      type: null,
+      default: null
+    },
+    defaultColor: {
+      type: null,
+      default: 'ff0000'
+    },
+    inline: {
+      type: Boolean,
+      default: false
+    },
+    format: {
+      type: String,
+      default: 'hex'
+    },
+    disabled: {
+      type: Boolean,
+      default: false
+    },
+    tabindex: {
+      type: String,
+      default: null
+    },
+    autoZIndex: {
+      type: Boolean,
+      default: true
+    },
+    baseZIndex: {
+      type: Number,
+      default: 0
+    },
+    appendTo: {
+      type: [String, Object],
+      default: 'body'
+    },
+    panelClass: {
+      type: String,
+      default: null
+    }
+  },
+  style: ColorPickerStyle
+};
+</script>

--- a/src/components/ColorPicker/ColorPicker.d.ts
+++ b/src/components/ColorPicker/ColorPicker.d.ts
@@ -1,0 +1,181 @@
+import {
+  ClassComponent,
+  GlobalComponentConstructor,
+  HintedString
+} from 'primevue/ts-helpers';
+
+/**
+ *
+ * ColorPicker groups a collection of contents in tabs.
+ *
+ * @module colorpicker
+ *
+ */
+
+/**
+ * Defines valid properties in ColorPicker component.
+ */
+export interface ColorPickerProps {
+  /**
+   * Value of the component.
+   */
+  modelValue?: any;
+  /**
+   * Initial color to display when value is not defined.
+   * @defaultValue ff0000
+   */
+  defaultColor?: any;
+  /**
+   * Whether to display as an overlay or not.
+   * @defaultValue false
+   */
+  inline?: boolean | undefined;
+  /**
+   * Format to use in value binding, supported formats are 'hex', 'rgb' and 'hsb'.
+   * @defaultValue hex
+   */
+  format?: 'hex' | 'rgb' | 'hsb' | undefined;
+  /**
+   * When present, it specifies that the component should be disabled.
+   * @defaultValue false
+   */
+  disabled?: boolean | undefined;
+  /**
+   * Index of the element in tabbing order.
+   */
+  tabindex?: string | undefined;
+  /**
+   * Whether to automatically manage layering.
+   * @defaultValue true
+   */
+  autoZIndex?: boolean | undefined;
+  /**
+   * Base zIndex value to use in layering.
+   * @defaultValue 0
+   */
+  baseZIndex?: number | undefined;
+  /**
+   * Style class of the overlay panel.
+   */
+  panelClass?: any;
+  /**
+   * A valid query selector or an HTMLElement to specify where the overlay gets attached. Special keywords are 'body' for document body and 'self' for the element itself.
+   * @defaultValue body
+   */
+  appendTo?: HintedString<'body' | 'self'> | undefined | HTMLElement;
+  /**
+   * Indicates whether or not to show the hex color input within the panel.
+   *
+   * @defaultValue true
+   */
+  showHexInput?: boolean | undefined;
+  /**
+   * Id for the screen reader hex color input field.
+   */
+  accessibleInputId?: string | undefined;
+}
+
+/**
+ * Defines current inline state in ColorPicker component.
+ */
+export interface ColorPickerState {
+  /**
+   * Current overlay visible state as a boolean.
+   * @defaultValue false
+   */
+  overlayVisible: boolean;
+}
+
+/**
+ * Custom passthrough(pt) option method.
+ */
+export interface ColorPickerPassThroughMethodOptions {
+  /**
+   * Defines instance.
+   */
+  instance: any;
+  /**
+   * Defines valid properties.
+   */
+  props: ColorPickerProps;
+  /**
+   * Defines current inline state.
+   */
+  state: ColorPickerState;
+  /**
+   * Defines valid attributes.
+   */
+  attrs: any;
+  /**
+   * Defines parent options.
+   */
+  parent: any;
+  /**
+   * Defines passthrough(pt) options in global config.
+   */
+  global: object | undefined;
+}
+
+/**
+ * Custom change event.
+ * @see {@link ColorPickerEmits.change}
+ */
+export interface ColorPickerChangeEvent {
+  /**
+   * Browser event
+   */
+  event: Event;
+  /**
+   * Selected color value.
+   */
+  value: any;
+}
+
+/**
+ * Custom passthrough attributes for each DOM elements
+ */
+export interface ColorPickerPassThroughAttributes {
+  [key: string]: any;
+}
+
+export interface ColorPickerSlots {}
+
+/**
+ * Defines valid emits in ColorPicker component.
+ */
+export interface ColorPickerEmits {
+  /**
+   * Emitted when the value changes.
+   * @param {*} value - New value.
+   */
+  'update:modelValue'(value: any): void;
+  /**
+   * Callback to invoke when a color is selected.
+   * @param {ColorPickerChangeEvent} event - Custom add event.
+   */
+  change(event: ColorPickerChangeEvent): void;
+  /**
+   * Callback to invoke when input is cleared by the user.
+   */
+  show(): void;
+  /**
+   * Callback to invoke when input is cleared by the user.
+   */
+  hide(): void;
+}
+
+declare module './ColorPicker.vue' {
+  declare class ColorPicker extends ClassComponent<
+    ColorPickerProps,
+    ColorPickerSlots,
+    ColorPickerEmits
+  > {}
+
+  export default ColorPicker;
+
+  declare module 'vue' {
+    export interface GlobalComponents {
+      ColorPicker: GlobalComponentConstructor<ColorPicker>;
+    }
+  }
+}

--- a/src/components/ColorPicker/ColorPicker.mdx
+++ b/src/components/ColorPicker/ColorPicker.mdx
@@ -1,0 +1,36 @@
+import { Canvas, ArgTypes, PRIMARY_STORY } from '@storybook/addon-docs';
+import {
+  Default,
+  Inline,
+  InlineNoHexInput,
+  NoHexInput
+} from '@/components/ColorPicker/ColorPicker.stories';
+
+# Color Picker
+
+A color picker is a component that allows users to select a color from a color palette.
+By default, the color picker will display a color input field, a color palette, and a hex input field.
+The hex input field may be hidden by setting the showHexInput prop to false.
+
+This component is a clone of the [PrimeVue ColorPicker component](https://primevue.org/colorpicker/), with the
+addition of the hex input field in the color picker panel and a non visible color input field for accessibility purposes.
+
+## Default Configuration
+
+<Canvas of={Default} />
+
+## Without Hex Input
+
+<Canvas of={NoHexInput} />
+
+## Inline
+
+<Canvas of={Inline} />
+
+## Inline - Without Hex Input
+
+<Canvas of={InlineNoHexInput} />
+
+## Props
+
+<ArgTypes story={PRIMARY_STORY} />

--- a/src/components/ColorPicker/ColorPicker.stories.ts
+++ b/src/components/ColorPicker/ColorPicker.stories.ts
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import ColorPickerType from '@/components/ColorPicker/ColorPicker';
+import ColorPicker from '@/components/ColorPicker/ColorPicker.vue';
+import mdx from './ColorPicker.mdx';
+
+const meta: Meta<typeof ColorPickerType> = {
+  title: 'Components/Color Picker',
+  component: ColorPicker,
+  parameters: {
+    docs: {
+      page: mdx
+    }
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ColorPickerType>;
+
+export const Default: Story = {
+  args: {
+    inputId: 'colorpicker-demo',
+    defaultColor: '#000000'
+  }
+};
+
+export const NoHexInput: Story = {
+  args: {
+    inputId: 'colorpicker-demo--no-hex-input',
+    defaultColor: '#000000',
+    showHexInput: false
+  }
+};
+
+export const Inline: Story = {
+  args: {
+    inputId: 'colorpicker-demo--inline',
+    defaultColor: '#000000',
+    inline: true
+  }
+};
+
+export const InlineNoHexInput: Story = {
+  args: {
+    inputId: 'colorpicker-demo--inline',
+    defaultColor: '#000000',
+    inline: true,
+    showHexInput: false
+  }
+};

--- a/src/components/ColorPicker/ColorPicker.vue
+++ b/src/components/ColorPicker/ColorPicker.vue
@@ -1,0 +1,849 @@
+<template>
+  <div ref="container" class="uic-color-picker">
+    <InputMask
+      v-if="showHexInput"
+      :id="accessibleInputId"
+      :model-value="hexValue"
+      :tabindex="tabindex"
+      :disabled="disabled"
+      placeholder="#ffffff"
+      class="sr-only"
+      mask="#******"
+      @blur="onHiddenInputBlur"
+      @keydown="onHiddenInputKeydown"
+      @focus="onHiddenInputFocus"
+    />
+    <input
+      v-if="!inline"
+      ref="input"
+      type="text"
+      class="uic-color-picker__input"
+      readonly="readonly"
+      tabindex="-1"
+      data-testid="color-picker-input"
+      :disabled="disabled"
+      @click="onInputClick"
+      @keydown="onInputKeydown"
+    />
+    <Portal :append-to="appendTo" :disabled="inline">
+      <transition
+        name="p-connected-overlay"
+        @enter="onOverlayEnter"
+        @leave="onOverlayLeave"
+        @after-leave="onOverlayAfterLeave"
+      >
+        <div
+          v-if="inline ? true : overlayVisible"
+          :ref="pickerRef"
+          :class="[
+            'uic-color-picker__panel',
+            panelClass,
+            showHexInput ? 'uic-color-picker__panel--hex-input' : '',
+            inline ? 'uic-color-picker__panel--inline' : ''
+          ]"
+          data-testid="color-picker-panel"
+          @click="onOverlayClick"
+        >
+          <div class="uic-color-picker__content">
+            <div
+              :ref="colorSelectorRef"
+              class="uic-color-picker__selector"
+              @mousedown="onColorMousedown($event)"
+              @touchstart="onColorDragStart($event)"
+              @touchmove="onDrag($event)"
+              @touchend="onDragEnd()"
+            >
+              <div class="uic-color-picker__color">
+                <div
+                  :ref="colorHandleRef"
+                  class="uic-color-picker__color-handle"
+                ></div>
+              </div>
+            </div>
+            <div
+              :ref="hueViewRef"
+              class="uic-color-picker__hue"
+              @mousedown="onHueMousedown($event)"
+              @touchstart="onHueDragStart($event)"
+              @touchmove="onDrag($event)"
+              @touchend="onDragEnd()"
+            >
+              <div
+                :ref="hueHandleRef"
+                class="uic-color-picker__hue-handle"
+              ></div>
+            </div>
+          </div>
+          <InputMask
+            v-if="showHexInput"
+            :model-value="hexValue"
+            mask="#******"
+            placeholder="#ffffff"
+            class="uic-color-picker__hex-input"
+            data-testid="color-picker-hex-input"
+            @blur="onHexInputBlur"
+            @keydown="onHexInputKeydown"
+          />
+        </div>
+      </transition>
+    </Portal>
+  </div>
+</template>
+
+<script>
+import OverlayEventBus from 'primevue/overlayeventbus';
+import Portal from 'primevue/portal';
+import {
+  ConnectedOverlayScrollHandler,
+  DomHandler,
+  ZIndexUtils
+} from 'primevue/utils';
+import BaseColorPicker from './BaseColorPicker.vue';
+import InputMask from 'primevue/inputmask';
+
+export default {
+  name: 'ColorPicker',
+  components: {
+    InputMask,
+    Portal
+  },
+  extends: BaseColorPicker,
+  inheritAttrs: false,
+  props: {
+    showHexInput: {
+      type: Boolean,
+      default: true
+    },
+    accessibleInputId: {
+      type: String,
+      default: null
+    }
+  },
+  emits: ['update:modelValue', 'change', 'show', 'hide'],
+  data() {
+    return {
+      overlayVisible: false,
+      hexValue: null
+    };
+  },
+  hsbValue: null,
+  outsideClickListener: null,
+  documentMouseMoveListener: null,
+  documentMouseUpListener: null,
+  scrollHandler: null,
+  resizeListener: null,
+  hueDragging: null,
+  colorDragging: null,
+  selfUpdate: null,
+  picker: null,
+  colorSelector: null,
+  colorHandle: null,
+  hueView: null,
+  hueHandle: null,
+  watch: {
+    modelValue: {
+      immediate: true,
+      handler(newValue) {
+        this.hsbValue = this.toHSB(newValue);
+
+        if (this.selfUpdate) this.selfUpdate = false;
+        else this.updateUI();
+      }
+    }
+  },
+  /* c8 ignore start */
+  beforeUnmount() {
+    this.unbindOutsideClickListener();
+    this.unbindDragListeners();
+    this.unbindResizeListener();
+
+    if (this.scrollHandler) {
+      this.scrollHandler.destroy();
+      this.scrollHandler = null;
+    }
+
+    if (this.picker && this.autoZIndex) {
+      ZIndexUtils.clear(this.picker);
+    }
+
+    this.clearRefs();
+  },
+  mounted() {
+    this.updateUI();
+  },
+  /* c8 ignore stop */
+  methods: {
+    pickColor(event) {
+      const rect = this.colorSelector.getBoundingClientRect();
+      const top =
+        rect.top +
+        (window.pageYOffset ||
+          document.documentElement.scrollTop ||
+          document.body.scrollTop ||
+          0);
+      const left = rect.left + document.body.scrollLeft;
+      const saturation = Math.floor(
+        (100 *
+          Math.max(
+            0,
+            Math.min(150, (event.pageX || event.changedTouches[0].pageX) - left)
+          )) /
+          150
+      );
+      const brightness = Math.floor(
+        (100 *
+          (150 -
+            Math.max(
+              0,
+              Math.min(
+                150,
+                (event.pageY || event.changedTouches[0].pageY) - top
+              )
+            ))) /
+          150
+      );
+
+      this.hsbValue = this.validateHSB({
+        h: this.hsbValue.h,
+        s: saturation,
+        b: brightness
+      });
+
+      this.selfUpdate = true;
+      this.updateColorHandle();
+      this.updateInput();
+      this.updateHexValue();
+      this.updateModel(event);
+    },
+    pickHue(event) {
+      const top =
+        this.hueView.getBoundingClientRect().top +
+        (window.pageYOffset ||
+          document.documentElement.scrollTop ||
+          document.body.scrollTop ||
+          0);
+
+      this.hsbValue = this.validateHSB({
+        h: Math.floor(
+          (360 *
+            (150 -
+              Math.max(
+                0,
+                Math.min(
+                  150,
+                  (event.pageY || event.changedTouches[0].pageY) - top
+                )
+              ))) /
+            150
+        ),
+        s: 100,
+        b: 100
+      });
+
+      this.selfUpdate = true;
+      this.updateColorSelector();
+      this.updateHue();
+      this.updateModel(event);
+      this.updateInput();
+      this.updateHexValue();
+    },
+    updateModel(event) {
+      let value = this.modelValue;
+
+      switch (this.format) {
+        case 'hex':
+          value = this.HSBtoHEX(this.hsbValue);
+          break;
+
+        case 'rgb':
+          value = this.HSBtoRGB(this.hsbValue);
+          break;
+
+        case 'hsb':
+          value = this.hsbValue;
+          break;
+
+        default:
+          //NoOp
+          break;
+      }
+
+      this.$emit('update:modelValue', value);
+      this.$emit('change', { event, value });
+    },
+    updateColorSelector() {
+      if (this.colorSelector) {
+        const hsbValue = this.validateHSB({
+          h: this.hsbValue.h,
+          s: 100,
+          b: 100
+        });
+
+        this.colorSelector.style.backgroundColor =
+          '#' + this.HSBtoHEX(hsbValue);
+      }
+    },
+    updateColorHandle() {
+      if (this.colorHandle) {
+        this.colorHandle.style.left =
+          Math.floor((150 * this.hsbValue.s) / 100) + 'px';
+        this.colorHandle.style.top =
+          Math.floor((150 * (100 - this.hsbValue.b)) / 100) + 'px';
+      }
+    },
+    updateHue() {
+      if (this.hueHandle) {
+        this.hueHandle.style.top =
+          Math.floor(150 - (150 * this.hsbValue.h) / 360) + 'px';
+      }
+    },
+    updateInput() {
+      if (this.$refs.input) {
+        this.$refs.input.style.backgroundColor =
+          '#' + this.HSBtoHEX(this.hsbValue);
+      }
+    },
+    updateHexValue() {
+      this.hexValue = this.HSBtoHEX(this.hsbValue);
+    },
+    updateUI() {
+      this.updateHue();
+      this.updateColorHandle();
+      this.updateInput();
+      this.updateColorSelector();
+      this.updateHexValue();
+    },
+    validateHSB(hsb) {
+      return {
+        h: Math.min(360, Math.max(0, hsb.h)),
+        s: Math.min(100, Math.max(0, hsb.s)),
+        b: Math.min(100, Math.max(0, hsb.b))
+      };
+    },
+    validateRGB(rgb) {
+      return {
+        r: Math.min(255, Math.max(0, rgb.r)),
+        g: Math.min(255, Math.max(0, rgb.g)),
+        b: Math.min(255, Math.max(0, rgb.b))
+      };
+    },
+    validateHEX(hex) {
+      var len = 6 - hex.length;
+
+      if (len > 0) {
+        var o = [];
+
+        for (var i = 0; i < len; i++) {
+          o.push('0');
+        }
+
+        o.push(hex);
+        hex = o.join('');
+      }
+
+      return hex;
+    },
+    HEXtoRGB(hex) {
+      const hexValue = parseInt(
+        hex.indexOf('#') > -1 ? hex.substring(1) : hex,
+        16
+      );
+
+      return {
+        r: hexValue >> 16,
+        g: (hexValue & 0x00ff00) >> 8,
+        b: hexValue & 0x0000ff
+      };
+    },
+    HEXtoHSB(hex) {
+      return this.RGBtoHSB(this.HEXtoRGB(hex));
+    },
+    RGBtoHSB(rgb) {
+      var hsb = {
+        h: 0,
+        s: 0,
+        b: 0
+      };
+      var min = Math.min(rgb.r, rgb.g, rgb.b);
+      var max = Math.max(rgb.r, rgb.g, rgb.b);
+      var delta = max - min;
+
+      hsb.b = max;
+      hsb.s = max !== 0 ? (255 * delta) / max : 0;
+
+      if (hsb.s !== 0) {
+        if (rgb.r === max) {
+          hsb.h = (rgb.g - rgb.b) / delta;
+        } else if (rgb.g === max) {
+          hsb.h = 2 + (rgb.b - rgb.r) / delta;
+        } else {
+          hsb.h = 4 + (rgb.r - rgb.g) / delta;
+        }
+      } else {
+        hsb.h = -1;
+      }
+
+      hsb.h *= 60;
+
+      if (hsb.h < 0) {
+        hsb.h += 360;
+      }
+
+      hsb.s *= 100 / 255;
+      hsb.b *= 100 / 255;
+
+      return hsb;
+    },
+    HSBtoRGB(hsb) {
+      var rgb = {
+        r: null,
+        g: null,
+        b: null
+      };
+      var h = Math.round(hsb.h);
+      var s = Math.round((hsb.s * 255) / 100);
+      var v = Math.round((hsb.b * 255) / 100);
+
+      if (s === 0) {
+        rgb = {
+          r: v,
+          g: v,
+          b: v
+        };
+      } else {
+        var t1 = v;
+        var t2 = ((255 - s) * v) / 255;
+        var t3 = ((t1 - t2) * (h % 60)) / 60;
+
+        if (h === 360) h = 0;
+
+        if (h < 60) {
+          rgb.r = t1;
+          rgb.b = t2;
+          rgb.g = t2 + t3;
+        } else if (h < 120) {
+          rgb.g = t1;
+          rgb.b = t2;
+          rgb.r = t1 - t3;
+        } else if (h < 180) {
+          rgb.g = t1;
+          rgb.r = t2;
+          rgb.b = t2 + t3;
+        } else if (h < 240) {
+          rgb.b = t1;
+          rgb.r = t2;
+          rgb.g = t1 - t3;
+        } else if (h < 300) {
+          rgb.b = t1;
+          rgb.g = t2;
+          rgb.r = t2 + t3;
+        } else if (h < 360) {
+          rgb.r = t1;
+          rgb.g = t2;
+          rgb.b = t1 - t3;
+        } else {
+          rgb.r = 0;
+          rgb.g = 0;
+          rgb.b = 0;
+        }
+      }
+
+      return {
+        r: Math.round(rgb.r),
+        g: Math.round(rgb.g),
+        b: Math.round(rgb.b)
+      };
+    },
+    RGBtoHEX(rgb) {
+      var hex = [rgb.r.toString(16), rgb.g.toString(16), rgb.b.toString(16)];
+
+      for (var key in hex) {
+        if (hex[key].length === 1) {
+          hex[key] = '0' + hex[key];
+        }
+      }
+
+      return hex.join('');
+    },
+    HSBtoHEX(hsb) {
+      return this.RGBtoHEX(this.HSBtoRGB(hsb));
+    },
+    toHSB(value) {
+      let hsb;
+
+      if (value) {
+        switch (this.format) {
+          case 'hex':
+            hsb = this.HEXtoHSB(value);
+            break;
+
+          case 'rgb':
+            hsb = this.RGBtoHSB(value);
+            break;
+
+          case 'hsb':
+            hsb = value;
+            break;
+
+          default:
+            break;
+        }
+      } else {
+        hsb = this.HEXtoHSB(this.defaultColor);
+      }
+
+      return hsb;
+    },
+    /* c8 ignore start */
+    onOverlayEnter(el) {
+      this.updateUI();
+      this.alignOverlay();
+      this.bindOutsideClickListener();
+      this.bindScrollListener();
+      this.bindResizeListener();
+
+      if (this.autoZIndex) {
+        ZIndexUtils.set(
+          'overlay',
+          el,
+          this.baseZIndex,
+          this.$primevue.config.zIndex.overlay
+        );
+      }
+
+      this.$emit('show');
+    },
+    onOverlayLeave() {
+      this.unbindOutsideClickListener();
+      this.unbindScrollListener();
+      this.unbindResizeListener();
+      this.clearRefs();
+      this.$emit('hide');
+    },
+    onOverlayAfterLeave(el) {
+      if (this.autoZIndex) {
+        ZIndexUtils.clear(el);
+      }
+    },
+    alignOverlay() {
+      if (this.appendTo === 'self')
+        DomHandler.relativePosition(this.picker, this.$refs.input);
+      else DomHandler.absolutePosition(this.picker, this.$refs.input);
+    },
+    /* c8 ignore stop */
+    onInputClick() {
+      if (this.disabled) {
+        return;
+      }
+
+      this.overlayVisible = !this.overlayVisible;
+    },
+    onInputKeydown(event) {
+      switch (event.code) {
+        case 'Space':
+          this.overlayVisible = !this.overlayVisible;
+          event.preventDefault();
+          break;
+
+        case 'Escape':
+        case 'Tab':
+          this.overlayVisible = false;
+          break;
+
+        default:
+          //NoOp
+          break;
+      }
+    },
+    onColorMousedown(event) {
+      if (this.disabled) {
+        return;
+      }
+
+      this.bindDragListeners();
+      this.onColorDragStart(event);
+    },
+    onColorDragStart(event) {
+      if (this.disabled) {
+        return;
+      }
+
+      this.colorDragging = true;
+      this.pickColor(event);
+      this.$el.setAttribute('p-colorpicker-dragging', 'true');
+      !this.isUnstyled &&
+        DomHandler.addClass(this.$el, 'p-colorpicker-dragging');
+      event.preventDefault();
+    },
+    onDrag(event) {
+      if (this.colorDragging) {
+        this.pickColor(event);
+        event.preventDefault();
+      }
+
+      if (this.hueDragging) {
+        this.pickHue(event);
+        event.preventDefault();
+      }
+    },
+    onDragEnd() {
+      this.colorDragging = false;
+      this.hueDragging = false;
+      this.$el.setAttribute('p-colorpicker-dragging', 'false');
+      !this.isUnstyled &&
+        DomHandler.removeClass(this.$el, 'p-colorpicker-dragging');
+      this.unbindDragListeners();
+    },
+    onHueMousedown(event) {
+      if (this.disabled) {
+        return;
+      }
+
+      this.bindDragListeners();
+      this.onHueDragStart(event);
+    },
+    onHueDragStart(event) {
+      if (this.disabled) {
+        return;
+      }
+
+      this.hueDragging = true;
+      this.pickHue(event);
+      !this.isUnstyled &&
+        DomHandler.addClass(this.$el, 'p-colorpicker-dragging');
+    },
+    isInputClicked(event) {
+      return this.$refs.input && this.$refs.input.isSameNode(event.target);
+    },
+    /* c8 ignore start */
+    bindDragListeners() {
+      this.bindDocumentMouseMoveListener();
+      this.bindDocumentMouseUpListener();
+    },
+    unbindDragListeners() {
+      this.unbindDocumentMouseMoveListener();
+      this.unbindDocumentMouseUpListener();
+    },
+    bindOutsideClickListener() {
+      if (!this.outsideClickListener) {
+        this.outsideClickListener = (event) => {
+          if (
+            this.overlayVisible &&
+            this.picker &&
+            !this.picker.contains(event.target) &&
+            !this.isInputClicked(event)
+          ) {
+            this.overlayVisible = false;
+          }
+        };
+
+        document.addEventListener('click', this.outsideClickListener);
+      }
+    },
+    unbindOutsideClickListener() {
+      if (this.outsideClickListener) {
+        document.removeEventListener('click', this.outsideClickListener);
+        this.outsideClickListener = null;
+      }
+    },
+    bindScrollListener() {
+      if (!this.scrollHandler) {
+        this.scrollHandler = new ConnectedOverlayScrollHandler(
+          this.$refs.container,
+          () => {
+            if (this.overlayVisible) {
+              this.overlayVisible = false;
+            }
+          }
+        );
+      }
+
+      this.scrollHandler.bindScrollListener();
+    },
+    unbindScrollListener() {
+      if (this.scrollHandler) {
+        this.scrollHandler.unbindScrollListener();
+      }
+    },
+    bindResizeListener() {
+      if (!this.resizeListener) {
+        this.resizeListener = () => {
+          if (this.overlayVisible && !DomHandler.isTouchDevice()) {
+            this.overlayVisible = false;
+          }
+        };
+
+        window.addEventListener('resize', this.resizeListener);
+      }
+    },
+    unbindResizeListener() {
+      if (this.resizeListener) {
+        window.removeEventListener('resize', this.resizeListener);
+        this.resizeListener = null;
+      }
+    },
+    bindDocumentMouseMoveListener() {
+      if (!this.documentMouseMoveListener) {
+        this.documentMouseMoveListener = this.onDrag.bind(this);
+        document.addEventListener('mousemove', this.documentMouseMoveListener);
+      }
+    },
+    unbindDocumentMouseMoveListener() {
+      if (this.documentMouseMoveListener) {
+        document.removeEventListener(
+          'mousemove',
+          this.documentMouseMoveListener
+        );
+        this.documentMouseMoveListener = null;
+      }
+    },
+    bindDocumentMouseUpListener() {
+      if (!this.documentMouseUpListener) {
+        this.documentMouseUpListener = this.onDragEnd.bind(this);
+        document.addEventListener('mouseup', this.documentMouseUpListener);
+      }
+    },
+    unbindDocumentMouseUpListener() {
+      if (this.documentMouseUpListener) {
+        document.removeEventListener('mouseup', this.documentMouseUpListener);
+        this.documentMouseUpListener = null;
+      }
+    },
+    pickerRef(el) {
+      this.picker = el;
+    },
+    colorSelectorRef(el) {
+      this.colorSelector = el;
+    },
+    colorHandleRef(el) {
+      this.colorHandle = el;
+    },
+    hueViewRef(el) {
+      this.hueView = el;
+    },
+    hueHandleRef(el) {
+      this.hueHandle = el;
+    },
+    clearRefs() {
+      this.picker = null;
+      this.colorSelector = null;
+      this.colorHandle = null;
+      this.hueView = null;
+      this.hueHandle = null;
+    },
+    onOverlayClick(event) {
+      OverlayEventBus.emit('overlay-click', {
+        originalEvent: event,
+        target: this.$el
+      });
+    },
+    /* c8 ignore stop */
+    onHexInputBlur(event) {
+      const hex = event.target.value;
+      const hsb = this.HEXtoHSB(hex);
+
+      this.hsbValue = hsb;
+      this.updateUI();
+      this.updateModel(event);
+    },
+    onHexInputKeydown($event) {
+      if (!/[a-f0-9]/i.test($event.key)) {
+        $event.preventDefault();
+      }
+    },
+    onHiddenInputFocus() {
+      if (this.inline) {
+        this.$refs.picker?.classList.add('uic-color-picker__panel--focused');
+      } else {
+        this.$refs.input?.classList.add('uic-color-picker__input--focused');
+      }
+    },
+    onHiddenInputBlur($event) {
+      if (this.inline) {
+        this.$refs.picker?.classList.remove('uic-color-picker__panel--focused');
+      } else {
+        this.$refs.input?.classList.remove('uic-color-picker__input--focused');
+      }
+
+      this.onHexInputBlur($event);
+    },
+    onHiddenInputKeydown($event) {
+      if (!/[a-f0-9]/i.test($event.key)) {
+        $event.preventDefault();
+      }
+
+      this.onInputKeydown($event);
+    }
+  }
+};
+</script>
+
+<style lang="scss">
+.uic-color-picker {
+  $root: &;
+
+  &__input {
+    @apply w-[32px] h-[32px] rounded-lg border-line-grey border-2 transition-colors duration-200 cursor-pointer;
+
+    &--focused {
+      @apply border-blue-500;
+    }
+  }
+
+  &__panel {
+    @apply absolute w-[193px] h-[166px] shadow-transparent bg-gray-800 border-black rounded-lg;
+
+    &--hex-input {
+      @apply h-[210px];
+    }
+
+    &--inline {
+      @apply relative;
+    }
+
+    &--focused {
+      @apply border-blue-500;
+    }
+  }
+
+  &__content {
+    @apply relative;
+  }
+
+  &__selector {
+    @apply absolute h-[150px] w-[150px] left-[8px] top-[8px];
+  }
+
+  &__color {
+    @apply h-[150px] w-[150px];
+    background: linear-gradient(to top, #000 0%, rgba(0, 0, 0, 0) 100%),
+      linear-gradient(to right, #fff 0%, rgba(255, 255, 255, 0) 100%);
+  }
+
+  &__color-handle {
+    @apply absolute w-[10px] h-[10px] -mt-[5px] -ml-[5px] border-white border cursor-pointer rounded-[100%];
+  }
+
+  &__hue {
+    @apply absolute h-[148px] w-[17px] top-[8px] left-[167px];
+    background: linear-gradient(
+      0deg,
+      red 0,
+      #ff0 17%,
+      #0f0 33%,
+      #0ff 50%,
+      #00f 67%,
+      #f0f 83%,
+      red
+    );
+  }
+
+  &__hue-handle {
+    @apply absolute w-[21px] -ml-[2px] -mt-[8px] h-[15px] border-2 border-white-100 rounded text-opacity-90 cursor-pointer;
+  }
+
+  &__hex-input {
+    @apply absolute w-[175px] h-[30px] left-[9px] top-[170px] bg-gray-800 border border-gray-400 p-1 text-gray-200 rounded-lg uppercase;
+  }
+}
+</style>

--- a/src/components/ColorPicker/__tests__/ColorPicker.spec.ts
+++ b/src/components/ColorPicker/__tests__/ColorPicker.spec.ts
@@ -1,0 +1,231 @@
+import '@testing-library/jest-dom';
+import {
+  RenderOptions,
+  fireEvent,
+  createEvent,
+  render,
+  waitFor,
+  screen
+} from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import ColorPicker from '../ColorPicker.vue';
+import PrimeVue from 'primevue/config';
+import { ColorPickerProps } from '@/components/ColorPicker/ColorPicker';
+
+const initialProps: ColorPickerProps = {
+  accessibleInputId: 'color-picker-input'
+};
+
+const renderComponent = (options: RenderOptions = {}) =>
+  render(ColorPicker, {
+    global: {
+      plugins: [PrimeVue]
+    },
+    ...options
+  });
+
+describe('ColorPicker', () => {
+  it('should render correctly', async () => {
+    const { baseElement, getByTestId } = renderComponent({
+      props: initialProps
+    });
+
+    const colorPickerInput = getByTestId('color-picker-input');
+    expect(colorPickerInput).toBeInTheDocument();
+    expect(colorPickerInput).toBeVisible();
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  it('should render the color picker when the input is clicked', async () => {
+    const { getByTestId } = renderComponent({
+      props: initialProps
+    });
+
+    const colorPickerInput = getByTestId('color-picker-input');
+    expect(colorPickerInput).toBeInTheDocument();
+
+    await userEvent.click(colorPickerInput);
+
+    await waitFor(() => {
+      const colorPickerPanel = screen.getByTestId('color-picker-panel'); // uses screen because the panel is transported ot the body
+      expect(colorPickerPanel).toBeInTheDocument();
+      expect(colorPickerPanel).toBeVisible();
+      expect(colorPickerPanel).toMatchSnapshot();
+    });
+  });
+
+  it('should render the color picker hex input within the color picker panel', async () => {
+    const { getByTestId } = renderComponent({
+      props: initialProps
+    });
+
+    const colorPickerInput = getByTestId('color-picker-input');
+    expect(colorPickerInput).toBeInTheDocument();
+
+    await userEvent.click(colorPickerInput);
+
+    await waitFor(() => {
+      const colorPickerHexInput = screen.getByTestId('color-picker-hex-input');
+      expect(colorPickerHexInput).toBeInTheDocument();
+      expect(colorPickerHexInput).toBeVisible();
+    });
+  });
+
+  it('should change the selected color on blur of the hex input', async () => {
+    const { getByTestId } = renderComponent({
+      props: initialProps
+    });
+
+    const colorPickerInput = getByTestId('color-picker-input');
+    expect(colorPickerInput).toBeInTheDocument();
+
+    await userEvent.click(colorPickerInput);
+
+    let colorPickerHexInput: HTMLInputElement | null = null;
+
+    await waitFor(() => {
+      colorPickerHexInput = screen.getByTestId(
+        'color-picker-hex-input'
+      ) as HTMLInputElement;
+      expect(colorPickerHexInput).toBeInTheDocument();
+      expect(colorPickerHexInput).toBeVisible();
+    });
+
+    await fireEvent.update(colorPickerHexInput!, 'ff00ff');
+    await fireEvent.blur(colorPickerHexInput!);
+
+    await waitFor(() => {
+      expect(colorPickerInput).toHaveStyle(
+        'background-color: rgb(255, 0, 255)'
+      );
+    });
+  });
+
+  it('should accept hex values in the accessible input', async () => {
+    const { container, getByTestId } = renderComponent({
+      props: initialProps
+    });
+
+    const accessibleInput = container.querySelector(
+      `#${initialProps.accessibleInputId}`
+    );
+    const colorPickerInput = getByTestId('color-picker-input');
+    expect(accessibleInput).toBeInTheDocument();
+    expect(colorPickerInput).toBeInTheDocument();
+
+    await fireEvent.blur(accessibleInput as HTMLInputElement, {
+      target: { value: 'ff00ff' }
+    });
+
+    await waitFor(() => {
+      expect(colorPickerInput).toHaveStyle(
+        'background-color: rgb(255, 0, 255)'
+      );
+    });
+  });
+
+  it('should show visual focus on the color input when the hidden input is focused', async () => {
+    const { container, getByTestId } = renderComponent({
+      props: initialProps
+    });
+
+    const accessibleInput = container.querySelector(
+      `#${initialProps.accessibleInputId}`
+    );
+    const colorPickerInput = getByTestId('color-picker-input');
+    expect(accessibleInput).toBeInTheDocument();
+    expect(colorPickerInput).toBeInTheDocument();
+
+    await fireEvent.focus(accessibleInput as HTMLInputElement);
+
+    await waitFor(() => {
+      expect(colorPickerInput).toHaveClass('uic-color-picker__input--focused');
+    });
+
+    await fireEvent.blur(accessibleInput as HTMLInputElement);
+
+    await waitFor(() => {
+      expect(colorPickerInput).not.toHaveClass(
+        'uic-color-picker__input--focused'
+      );
+    });
+  });
+
+  it('should not allow invalid hex values in the accessible input', async () => {
+    const defaultColor = '#000000';
+    const { container, getByTestId } = renderComponent({
+      props: { ...initialProps, defaultColor }
+    });
+
+    const accessibleInput: HTMLInputElement | null = container.querySelector(
+      `#${initialProps.accessibleInputId}`
+    );
+    const colorPickerInput = getByTestId('color-picker-input');
+    expect(accessibleInput).toBeInTheDocument();
+    expect(colorPickerInput).toBeInTheDocument();
+
+    await fireEvent.blur(accessibleInput as HTMLInputElement, {
+      target: { value: 'ff00f' }
+    });
+
+    await waitFor(() => {
+      expect(colorPickerInput).toHaveStyle({
+        backgroundColor: 'rgb(0, 0, 0)'
+      });
+    });
+
+    await fireEvent.keyDown(accessibleInput as HTMLInputElement, 'q');
+
+    expect(accessibleInput!.value).not.toContain('q');
+  });
+
+  it('should respond to mouse events', async () => {
+    const { getByTestId } = renderComponent({
+      props: initialProps
+    });
+
+    const colorPickerInput = getByTestId('color-picker-input');
+    expect(colorPickerInput).toBeInTheDocument();
+
+    await userEvent.click(colorPickerInput);
+
+    let colorPickerPanel;
+
+    await waitFor(() => {
+      colorPickerPanel = screen.getByTestId('color-picker-panel'); // uses screen because the panel is transported ot the body
+      expect(colorPickerPanel).toBeInTheDocument();
+      expect(colorPickerPanel).toBeVisible();
+    });
+
+    const colorSelector = colorPickerPanel!.querySelector(
+      '.uic-color-picker__selector'
+    );
+
+    const event = { pageX: 100, pageY: 120, preventDefault: () => {} };
+    const event2 = { pageX: 5, pageY: 20, preventDefault: () => {} };
+
+    // starts with the default color
+    expect(colorPickerInput).toHaveStyle({
+      backgroundColor: 'rgb(255, 0, 0)'
+    });
+
+    const mousedownEvent = Object.assign(
+      createEvent('mousedown', colorSelector, event),
+      event
+    );
+    await fireEvent(colorSelector, mousedownEvent);
+
+    const mousemoveEvent = Object.assign(
+      createEvent('mousemove', colorSelector, event),
+      event2
+    );
+
+    await fireEvent(colorSelector, mousemoveEvent);
+
+    await waitFor(() => {
+      expect(colorPickerInput.style.backgroundColor).not.toEqual(
+        'rgb(255, 0, 0)'
+      );
+    });
+  });
+});

--- a/src/components/ColorPicker/__tests__/__snapshots__/ColorPicker.spec.ts.snap
+++ b/src/components/ColorPicker/__tests__/__snapshots__/ColorPicker.spec.ts.snap
@@ -1,0 +1,65 @@
+// Vitest Snapshot v1
+
+exports[`ColorPicker > should render correctly 1`] = `
+<body>
+  <div>
+    <div
+      class="uic-color-picker"
+    >
+      <input
+        class="p-inputmask p-inputtext p-component p-filled sr-only"
+        data-pc-name="inputmask"
+        data-pc-section="root"
+        id="color-picker-input"
+        placeholder="#ffffff"
+      />
+      <input
+        class="uic-color-picker__input"
+        data-testid="color-picker-input"
+        readonly=""
+        style="background-color: rgb(255, 0, 0);"
+        tabindex="-1"
+        type="text"
+      />
+      <!---->
+    </div>
+  </div>
+</body>
+`;
+
+exports[`ColorPicker > should render the color picker when the input is clicked 1`] = `
+<div
+  class="uic-color-picker__panel uic-color-picker__panel--hex-input"
+  data-testid="color-picker-panel"
+>
+  <div
+    class="uic-color-picker__content"
+  >
+    <div
+      class="uic-color-picker__selector"
+    >
+      <div
+        class="uic-color-picker__color"
+      >
+        <div
+          class="uic-color-picker__color-handle"
+        />
+      </div>
+    </div>
+    <div
+      class="uic-color-picker__hue"
+    >
+      <div
+        class="uic-color-picker__hue-handle"
+      />
+    </div>
+  </div>
+  <input
+    class="p-inputmask p-inputtext p-component p-filled uic-color-picker__hex-input"
+    data-pc-name="inputmask"
+    data-pc-section="root"
+    data-testid="color-picker-hex-input"
+    placeholder="#ffffff"
+  />
+</div>
+`;

--- a/src/components/ColorPicker/index.ts
+++ b/src/components/ColorPicker/index.ts
@@ -1,0 +1,1 @@
+export { default as ColorPicker } from './ColorPicker.vue';

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,7 @@ export * from './components/Badge';
 export * from './components/Icon';
 export * from './components/Modal';
 export * from './components/ImageFileUpload';
+export * from './components/ColorPicker';
 
 export default ComponentLibrary;
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,7 +21,8 @@ module.exports = {
       colors: {
         purple: {
           800: '#483AC5'
-        }
+        },
+        'line-grey': '#E3E1EB'
       }
     }
   },


### PR DESCRIPTION
## JIRA

[MI-153](https://lobsters.atlassian.net/browse/MI-153)

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

Adds a color picker component, which is a clone (rather than a wrapper of) the PrimeVue Color Picker.  The clone has been tweaked to include a hex color input field within the color picker panel, so a specific color value can be entered versus dragging the color and hue handles to arrive at the desired color value.  Additionally, a non-visible hex input field has been added to support accessibility features and be screen reader compatible (not to mention more unit-test friendly).

<!--
## Screenshots
- before and after screenshots for features with visual changes
-->

![image](https://github.com/lob/ui-components/assets/3537215/c71e341c-fdb3-4545-85ce-a91ff4d7dead)

<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.


[MI-153]: https://lobsters.atlassian.net/browse/MI-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ