### PR TITLE
MI-153: Allow pasting hex color into color picker input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v2.0.40
+
+- Fix: Unable to paste hex code into `<ColorPicker />` hex input.
+
 ## v2.0.39
 
 - Type `<Table />` components
@@ -58,6 +62,8 @@
   - `UserChatBubble`
 
 ## v2.0.30
+
+- Add `<ColorPicker />` component
 
 ## v2.0.29
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.39",
+  "version": "2.0.40",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "2.0.39",
+      "version": "2.0.40",
       "dependencies": {
         "date-fns": "^2.29.3",
         "date-fns-holiday-us": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.39",
+  "version": "2.0.40",
   "engines": {
     "node": ">=20.2.0",
     "npm": ">=10.2.0"

--- a/src/components/ColorPicker/ColorPicker.vue
+++ b/src/components/ColorPicker/ColorPicker.vue
@@ -83,6 +83,7 @@
             data-testid="color-picker-hex-input"
             @blur="onHexInputBlur"
             @keydown="onHexInputKeydown"
+            @paste="onHexInputPaste"
           />
         </div>
       </transition>
@@ -747,6 +748,14 @@ export default {
       this.updateModel(event);
     },
     onHexInputKeydown($event) {
+      if (
+        $event.key === 'Tab' ||
+        $event.key === 'Meta' ||
+        $event.key === 'Control' ||
+        ($event.key === 'v' && ($event.metaKey || $event.ctrlKey))
+      ) {
+        return;
+      }
       if (!/[a-f0-9]/i.test($event.key)) {
         $event.preventDefault();
       }
@@ -773,6 +782,14 @@ export default {
       }
 
       this.onInputKeydown($event);
+    },
+    onHexInputPaste($event) {
+      const hex = this.validateHEX($event.clipboardData.getData('text'));
+      const hsb = this.HEXtoHSB(hex);
+
+      this.hsbValue = hsb;
+      this.updateUI();
+      this.updateModel($event);
     }
   }
 };

--- a/src/components/ColorPicker/__tests__/ColorPicker.spec.ts
+++ b/src/components/ColorPicker/__tests__/ColorPicker.spec.ts
@@ -102,7 +102,7 @@ describe('ColorPicker', () => {
   });
 
   it('should allow pasting a hex value in the hex input', async () => {
-    const { getByTestId } = renderComponent({
+    const { getByTestId, findByTestId } = renderComponent({
       props: initialProps
     });
 
@@ -111,15 +111,9 @@ describe('ColorPicker', () => {
 
     await userEvent.click(colorPickerInput);
 
-    let colorPickerHexInput: HTMLInputElement | null = null;
+    const colorPickerHexInput = await findByTestId('color-picker-hex-input');
 
-    await waitFor(() => {
-      colorPickerHexInput = screen.getByTestId(
-        'color-picker-hex-input'
-      ) as HTMLInputElement;
-      expect(colorPickerHexInput).toBeInTheDocument();
-      expect(colorPickerHexInput).toBeVisible();
-    });
+    expect(colorPickerHexInput).toBeVisible();
 
     await fireEvent.paste(colorPickerHexInput!, {
       clipboardData: { getData: () => 'ff00ff' }

--- a/src/components/ColorPicker/__tests__/ColorPicker.spec.ts
+++ b/src/components/ColorPicker/__tests__/ColorPicker.spec.ts
@@ -101,6 +101,37 @@ describe('ColorPicker', () => {
     });
   });
 
+  it('should allow pasting a hex value in the hex input', async () => {
+    const { getByTestId } = renderComponent({
+      props: initialProps
+    });
+
+    const colorPickerInput = getByTestId('color-picker-input');
+    expect(colorPickerInput).toBeInTheDocument();
+
+    await userEvent.click(colorPickerInput);
+
+    let colorPickerHexInput: HTMLInputElement | null = null;
+
+    await waitFor(() => {
+      colorPickerHexInput = screen.getByTestId(
+        'color-picker-hex-input'
+      ) as HTMLInputElement;
+      expect(colorPickerHexInput).toBeInTheDocument();
+      expect(colorPickerHexInput).toBeVisible();
+    });
+
+    await fireEvent.paste(colorPickerHexInput!, {
+      clipboardData: { getData: () => 'ff00ff' }
+    });
+
+    await waitFor(() => {
+      expect(colorPickerInput).toHaveStyle(
+        'background-color: rgb(255, 0, 255)'
+      );
+    });
+  });
+
   it('should accept hex values in the accessible input', async () => {
     const { container, getByTestId } = renderComponent({
       props: initialProps


### PR DESCRIPTION
## JIRA

[MI-153](https://lobsters.atlassian.net/browse/MI-153)

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

Fixes an issue where a hex color code could not be pasted into the ColorPicker's Hex Input

<!--
## Screenshots
- before and after screenshots for features with visual changes
-->

<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.


[MI-153]: https://lobsters.atlassian.net/browse/MI-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ