### PR TITLE
GC-00/adds disabled prop to DateInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v2.0.42
+
+- Add `disabled` prop to `<DateInput />` component
+
 ## v2.0.41
 
 - Add `<Menu />` component

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.41",
+  "version": "2.0.42",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "2.0.41",
+      "version": "2.0.42",
       "dependencies": {
         "date-fns": "^2.29.3",
         "date-fns-holiday-us": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.41",
+  "version": "2.0.42",
   "engines": {
     "node": ">=20.2.0",
     "npm": ">=10.2.0"

--- a/src/components/DateInput/DateInput.stories.js
+++ b/src/components/DateInput/DateInput.stories.js
@@ -40,7 +40,12 @@ export default {
         type: 'text'
       }
     }
-  }
+  },
+  disabled: {
+    control: {
+      type: 'boolean'
+    }
+  },
 };
 
 const startDate = new Date();

--- a/src/components/DateInput/DateInput.stories.js
+++ b/src/components/DateInput/DateInput.stories.js
@@ -45,7 +45,7 @@ export default {
     control: {
       type: 'boolean'
     }
-  },
+  }
 };
 
 const startDate = new Date();

--- a/src/components/DateInput/DateInput.vue
+++ b/src/components/DateInput/DateInput.vue
@@ -8,7 +8,8 @@
       :size="size"
       :error="error"
       :aria-describedby="error ? 'error-message' : ''"
-      @click.stop="isOpen = !isOpen"
+      :disabled="disabled"
+      @click.stop="isOpen = !disabled ? !isOpen : isOpen"
       @keydown.space.stop="isOpen = !isOpen"
     >
       <template #iconRight>
@@ -101,6 +102,10 @@ export default {
     errorMessage: {
       type: [String, null],
       default: null
+    },
+    disabled: {
+      type: Boolean,
+      default: false
     }
   },
   emits: ['update:modelValue', 'update:open'],


### PR DESCRIPTION
## Description

Allows disabling the `<DateInput />` component

<img width="367" alt="image" src="https://github.com/lob/ui-components/assets/83967528/b1cecc66-3bab-49b5-bc9b-2b5152b3bef0">