### PR TITLE
SELF-275/Fix icon button click emitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v2.0.46
+
+- Fix click event emission in `IconButton`
+
 ## v2.0.45
 
 - Fix sizing issues in `Ellipsis` and `EllipsisVertical`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.45",
+  "version": "2.0.46",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "2.0.45",
+      "version": "2.0.46",
       "dependencies": {
         "date-fns": "^2.29.3",
         "date-fns-holiday-us": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.45",
+  "version": "2.0.46",
   "engines": {
     "node": ">=20.2.0",
     "npm": ">=10.2.0"

--- a/src/components/IconButton/IconButton.vue
+++ b/src/components/IconButton/IconButton.vue
@@ -11,7 +11,7 @@
       :class="`uic-icon-button size-${size} color-${color} variant-${variant}`"
       :disabled="disabled"
       data-testid="uic-icon-button"
-      @click="$emit('click')"
+      @click="$emit('click', $event)"
     >
       <Icon :icon="icon" :size="iconSize" />
     </Button>
@@ -55,7 +55,7 @@ const props = withDefaults(
 );
 
 defineEmits<{
-  (e: 'click'): void; // eslint-disable-line no-unused-vars
+  (e: 'click', payload: MouseEvent): void; // eslint-disable-line no-unused-vars
 }>();
 
 const iconSize = computed(() => {


### PR DESCRIPTION
## SELF-275

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

- Icon button didn't pass the mouse event to its click emitter, which prevented the menu/overlay components from working with it.
<!--
## Screenshots
- before and after screenshots for features with visual changes
-->

<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
