### PR TITLE
SELF-287 update Menu.vue to include menu class with mb-2 if footer slot is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
-## v2.0.48
+## v2.0.50
+
+- Adjust the margin on the menu's divider if the menu has a footer.
+
+## v2.0.49
 
 - Add disabled styles for the items of the `Menu` component.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.49",
+  "version": "2.0.50",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/ui-components",
-      "version": "2.0.49",
+      "version": "2.0.50",
       "dependencies": {
         "date-fns": "^2.29.3",
         "date-fns-holiday-us": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/ui-components",
-  "version": "2.0.49",
+  "version": "2.0.50",
   "engines": {
     "node": ">=20.2.0",
     "npm": ">=10.2.0"

--- a/src/components/Menu/Menu.vue
+++ b/src/components/Menu/Menu.vue
@@ -10,7 +10,8 @@
         enterActiveClass: 'transition duration-250 ease-out',
         leaveActiveClass: 'transition duration-250 ease-out',
         leaveToClass: 'opacity-0 scale-[.98]'
-      }
+      },
+      menu: { class: [{ 'mb-2': Boolean($slots.footer) }] }
     }"
   >
     <template #submenuheader="item">


### PR DESCRIPTION
## SELF-287

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

- Updates Menu.vue to include menu class with mb-2 if footer slot is present

## Screenshots
![image](https://github.com/lob/ui-components/assets/37313064/d7fd0b40-2e8b-4ace-892b-1832d979a154)


<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.
