### PR TITLE
update deprecated github actions

### DIFF
--- a/.github/actions/install-node-and-npm/action.yml
+++ b/.github/actions/install-node-and-npm/action.yml
@@ -17,14 +17,14 @@ runs:
 
     - name: Read node version from package.json engines
       id: node_version
-      uses: notiz-dev/github-action-json-property@v0.1.0
+      uses: notiz-dev/github-action-json-property@v0.2.0
       with:
         path: 'package.json'
         prop_path: 'engines.node'
 
     - name: Read npm version from package.json engines
       id: npm_version
-      uses: notiz-dev/github-action-json-property@v0.1.0
+      uses: notiz-dev/github-action-json-property@v0.2.0
       with:
         path: 'package.json'
         prop_path: 'engines.npm'

--- a/.github/actions/install-node-and-npm/action.yml
+++ b/.github/actions/install-node-and-npm/action.yml
@@ -13,7 +13,7 @@ runs:
   using: composite
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Read node version from package.json engines
       id: node_version
@@ -30,7 +30,7 @@ runs:
         prop_path: 'engines.npm'
 
     - name: Install Node ${{ steps.node_version.outputs.prop }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ steps.node_version.outputs.prop }}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -55,7 +55,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -68,6 +68,6 @@ jobs:
       #   ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: '/language:${{matrix.language}}'

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Setup node and npm with the versions defined in package.json engines.
       - name: Install node and npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Setup node and npm with the versions defined in package.json engines.
       - name: Install node and npm
@@ -37,7 +37,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Setup node and npm with the versions defined in package.json engines.
       - name: Install node and npm
@@ -51,7 +51,7 @@ jobs:
 
       - name: Publish the package to npm
         id: publish
-        uses: JS-DevTools/npm-publish@v1
+        uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ env.NPM_TOKEN }}
           # only publish if the version in package.json has changed
@@ -59,7 +59,7 @@ jobs:
 
       - name: Add git tag ${{ steps.publish.outputs.version }}
         if: steps.publish.outputs.type != 'none'
-        uses: actions/github-script@v5
+        uses: actions/github-script@v7
         env:
           NEW_VERSION: '${{ steps.publish.outputs.version }}'
           OLD_VERSION: '${{ steps.publish.outputs.old-version }}'


### PR DESCRIPTION
## JIRA

- [PLAT-2193](https://lobsters.atlassian.net/browse/PLAT-2193)

<!--
## Technical Design Doc
- link to TDD if the feature had one (optional)
-->

## Description

- `actions/checkout@v3`, `notiz-dev/github-action-json-property@v0.1.0`, `actions/setup-node@v3`, `github/codeql-action/*@v2`,  `JS-DevTools/npm-publish@v1` and `actions/github-script@v5` run Node 12 or 16 and are deprecated, we need them to run Node 20:

See:
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
and
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

---

_Note: [`notiz-dev/github-action-json-property`](https://github.com/notiz-dev/github-action-json-property) can only be updated to Node 16 as [v0.2.0](https://github.com/notiz-dev/github-action-json-property/releases/tag/v0.2.0) is the latest release (from Nov 7, 2022)_

---

![image](https://github.com/lob/ui-components/assets/117756379/679cb95e-48d4-4841-adf6-c408d82a2fd5)

![image](https://github.com/lob/ui-components/assets/117756379/b27799f1-840b-49c7-800d-672f3de18196)


<!--
## Screenshots
- before and after screenshots for features with visual changes
-->

<!--
## Tests
- info about what was used to validate the feature (more for larger, more complicated features)
-->

<!--
## Areas of Concern
- to call out what could be a problem (optional)
-->

<!--
## Questions
- to ask any questions for the reviewers (optional)
-->

<!--
## GIFs/Memes
- (optional)
-->

## Reviewer Checklist

This section is to be filled out by reviewers

### Testing

- [ ] This code was tested by somebody other than the developer. Do not merge until this has been done.


[PLAT-2193]: https://lobsters.atlassian.net/browse/PLAT-2193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ